### PR TITLE
Enhance/press2-12 Theme installer endpoint

### DIFF
--- a/includes/Models/Theme.php
+++ b/includes/Models/Theme.php
@@ -7,75 +7,74 @@ namespace NewfoldLabs\WP\Module\Onboarding\Models;
  */
 class Theme implements \JsonSerializable {
 
-    private string $theme_name;
-    private string $theme_image;
-    private bool $is_newfold_theme;
+	private string $theme_name;
+	private string $theme_image;
+	private bool $is_newfold_theme;
 
-    /**
-     * @param string $theme_name
-     */
-    public function __construct( $theme_name ) 
-    {
-        $this->theme_name = $theme_name;
-        $this->is_newfold_theme = false;
-    }
+	/**
+	 * @param string $theme_name
+	 */
+	public function __construct( $theme_name ) {
+		$this->theme_name       = $theme_name;
+		$this->is_newfold_theme = false;
+	}
 
-    /**
-     * @param string $theme_name
-     * 
-     * @return void
-     */
-    public function set_theme_name( $theme_name ) {
-        $this->theme_name = $theme_name;
-    }
+	/**
+	 * @param string $theme_name
+	 *
+	 * @return void
+	 */
+	public function set_theme_name( $theme_name ) {
+		$this->theme_name = $theme_name;
+	}
 
-    /**
-     * @return string $theme_name
-     */
-    public function get_theme_name() {
-        return $this->theme_name;
-    }
+	/**
+	 * @return string $theme_name
+	 */
+	public function get_theme_name() {
+		return $this->theme_name;
+	}
 
-    /**
-     * @param string $theme_image Path to theme screenshot image.
-     * 
-     * @return void
-     */
-    public function set_theme_image( $theme_image ) {
-        $this->theme_image = $theme_image;
-    }
+	/**
+	 * @param string $theme_image Path to theme screenshot image.
+	 *
+	 * @return void
+	 */
+	public function set_theme_image( $theme_image ) {
+		$this->theme_image = $theme_image;
+	}
 
-    /**
-     * @return $theme_image Path to theme screenshot image.
-     */
-    public function get_theme_image() {
-        return $this->theme_image;
-    }
+	/**
+	 * @return $theme_image Path to theme screenshot image.
+	 */
+	public function get_theme_image() {
+		return $this->theme_image;
+	}
 
-    /**
-     * @param boolean $is_newfold_theme
-     * 
-     * @return void
-     */
-    public function set_is_newfold_theme( $is_newfold_theme ) {
-        $this->is_newfold_theme = $is_newfold_theme;
-    }
+	/**
+	 * @param boolean $is_newfold_theme
+	 *
+	 * @return void
+	 */
+	public function set_is_newfold_theme( $is_newfold_theme ) {
+		$this->is_newfold_theme = $is_newfold_theme;
+	}
 
-    /**
-     * @return boolean $is_newfold_theme true if the theme author is Newfold Digital.
-     */
-    public function get_is_newfold_theme() {
-        return $this->is_newfold_theme;
-    }
+	/**
+	 * @return boolean $is_newfold_theme true if the theme author is Newfold Digital.
+	 */
+	public function get_is_newfold_theme() {
+		return $this->is_newfold_theme;
+	}
 
-    /**
-     * @return array JSON Serialize the data
-     */
-    public function jsonSerialize() {
-        return array(
-            'name'           => $this->theme_name,
-            'image'          => $this->theme_image,
-            'isNewfoldTheme' => $this->is_newfold_theme
-        );
-    }
+	/**
+	 * @return array JSON Serialize the data
+	 */
+	public function jsonSerialize() {
+		return array(
+			'name'           => $this->theme_name,
+			'image'          => $this->theme_image,
+			'isNewfoldTheme' => $this->is_newfold_theme,
+		);
+	}
 }

--- a/includes/RestApi/BaseHiiveController.php
+++ b/includes/RestApi/BaseHiiveController.php
@@ -7,40 +7,40 @@ namespace NewfoldLabs\WP\Module\Onboarding\RestApi;
  */
 abstract class BaseHiiveController extends \WP_REST_Controller {
 
-    /**
-     * @var string
-     */
-    protected $url;
+	/**
+	 * @var string
+	 */
+	protected $url;
 
-    public function __construct() {
+	public function __construct() {
 
-        if ( ! defined( 'NFD_HIIVE_BASE_URL' ) ) {
-            define( 'NFD_HIIVE_BASE_URL', 'https://hiive.cloud');
-        }
+		if ( ! defined( 'NFD_HIIVE_BASE_URL' ) ) {
+			define( 'NFD_HIIVE_BASE_URL', 'https://hiive.cloud' );
+		}
 
-        $this->url = NFD_HIIVE_BASE_URL;
-    }
+		$this->url = NFD_HIIVE_BASE_URL;
+	}
 
-    /**
-     * @param string $endpoint
-     * @param array $args
-     * 
-     * @return WP_Error|string containing the Hiive response.
-     */
-    protected function get ( $endpoint, $args = array() ) {
-        $request = $this->url . $endpoint . '?' . http_build_query( $args );
+	/**
+	 * @param string $endpoint
+	 * @param array  $args
+	 *
+	 * @return WP_Error|string containing the Hiive response.
+	 */
+	protected function get( $endpoint, $args = array() ) {
+		$request = $this->url . $endpoint . '?' . http_build_query( $args );
 
-        $response = \wp_remote_get( $request );
-        if ( 200 === \wp_remote_retrieve_response_code( $response ) ) {
-            $payload = \wp_remote_retrieve_body( $response );
+		$response = \wp_remote_get( $request );
+		if ( 200 === \wp_remote_retrieve_response_code( $response ) ) {
+			$payload = \wp_remote_retrieve_body( $response );
 
-            return $payload;
-        }
+			return $payload;
+		}
 
-        return new \WP_Error(
-            'hiive-error',
-            'Error in fetching data.',
-            array( 'status' => \wp_remote_retrieve_response_code( $response ) )
-        );
-    }
+		return new \WP_Error(
+			'hiive-error',
+			'Error in fetching data.',
+			array( 'status' => \wp_remote_retrieve_response_code( $response ) )
+		);
+	}
 }

--- a/includes/RestApi/RestApi.php
+++ b/includes/RestApi/RestApi.php
@@ -7,25 +7,24 @@ namespace NewfoldLabs\WP\Module\Onboarding\RestApi;
  */
 final class RestApi {
 
-    protected $controllers = array(
-        'NewfoldLabs\\WP\\Module\\Onboarding\\RestApi\\SiteImagesController',
-        'NewfoldLabs\WP\\Module\\Onboarding\\RestApi\\Themes\\ApprovedThemesController'
-    );
+	protected $controllers = array(
+		'NewfoldLabs\\WP\\Module\\Onboarding\\RestApi\\SiteImagesController',
+		'NewfoldLabs\WP\\Module\\Onboarding\\RestApi\\Themes\\ApprovedThemesController',
+	);
 
-    public function __construct()
-    {
-        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
-    }
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
 
-    public function register_routes() {
-        foreach ( $this->controllers as $controller ) {
-            /**
-             * Get an instance of the WP_REST_Controller.
-             *
-             * @var $instance WP_REST_Controller
-             */
-            $instance = new $controller();
-            $instance->register_routes();
-        }
-    }
+	public function register_routes() {
+		foreach ( $this->controllers as $controller ) {
+			/**
+			 * Get an instance of the WP_REST_Controller.
+			 *
+			 * @var $instance WP_REST_Controller
+			 */
+			$instance = new $controller();
+			$instance->register_routes();
+		}
+	}
 } // END \NewfoldLabs\WP\Module\Onboarding\RestApi()

--- a/includes/RestApi/Themes/ApprovedThemesController.php
+++ b/includes/RestApi/Themes/ApprovedThemesController.php
@@ -9,111 +9,112 @@ use NewfoldLabs\WP\Module\Onboarding\Permissions;
  */
 class ApprovedThemesController extends \WP_REST_Controller {
 
-    /**
-     * The namespace of this controller's route.
-     *
-     * @var string
-     */
-    protected $namespace = 'newfold-onboarding/v1';
-	    
-    /**
-     * The base of this controller's route.
-     *
-     * @var string
-     */
-    protected $rest_base = 'themes';
+	/**
+	 * The namespace of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'newfold-onboarding/v1';
 
-    /**
-     * Registers the settings route
-     */
-    public function register_routes() {
-        \register_rest_route(
-            $this->namespace,
-            '/'. $this->rest_base,
-            array(
-                array(
-                    'methods'             => \WP_REST_Server::READABLE,
-                    'callback'            => array( $this, 'get_approved_themes' ),
-                    'permission_callback' => array( $this, 'check_permission' ),
-                )
-            )
-        );
-    }
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'themes';
 
-    /**
-     * Get a list of approved themes.
-     *
-     * [TODO] Retrieve the list from Hiive.
-     * 
-     * @return array|\WP_Error
-     */
-    protected function get_approved_theme_slugs() {
+	/**
+	 * Registers the settings route
+	 */
+	public function register_routes() {
+		\register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_approved_themes' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+			)
+		);
+	}
 
-        // Key-Value array implementation of approved themes for faster lookup
-        return array( 'twentytwentytwo' => 1 );
-    }
+	/**
+	 * Get a list of approved themes.
+	 *
+	 * [TODO] Retrieve the list from Hiive.
+	 *
+	 * @return array|\WP_Error
+	 */
+	protected function get_approved_theme_slugs() {
 
-    /**
-     * Retrieves list of installed themes.
-     *
-     * @return array|\WP_Error
-     */
-    public function get_installed_themes() {
+		// Key-Value array implementation of approved themes for faster lookup
+		return array( 'twentytwentytwo' => 1 );
+	}
 
-        $request = new \WP_REST_Request(
-            'GET',
-            '/wp/v2/' . $this->rest_base
-        );
-        $response = \rest_do_request( $request );
+	/**
+	 * Retrieves list of installed themes.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public function get_installed_themes() {
 
-        if (200 === $response->status) {
-            $themes_data = json_decode( \wp_json_encode( $response->data ), true );
-            foreach( $themes_data as $theme_data ) {
-                $theme = new Theme( $theme_data['template'] );
-                $theme->set_theme_image( $theme_data['screenshot'] );
-                if( str_contains( $theme_data['author']['raw'], 'Newfold Digital' ) )
-                    $theme->set_is_newfold_theme( true );
-                $installed_themes[] = $theme;
-            }
+		$request  = new \WP_REST_Request(
+			'GET',
+			'/wp/v2/' . $this->rest_base
+		);
+		$response = \rest_do_request( $request );
 
-            return $installed_themes;
-        }
+		if ( 200 === $response->status ) {
+			$themes_data = json_decode( \wp_json_encode( $response->data ), true );
+			foreach ( $themes_data as $theme_data ) {
+				$theme = new Theme( $theme_data['template'] );
+				$theme->set_theme_image( $theme_data['screenshot'] );
+				if ( str_contains( $theme_data['author']['raw'], 'Newfold Digital' ) ) {
+					$theme->set_is_newfold_theme( true );
+				}
+				$installed_themes[] = $theme;
+			}
 
-        return new \WP_Error(
-            $response->status,
-            'Failed to fetch installed themes.'
-        );
-    }
+			return $installed_themes;
+		}
 
-    /**
-     * Retrieves the themes offered by the Onboarding Module.
-     *
-     * @return \WP_REST_RESPONSE|\WP_Error
-     */
-    public function get_approved_themes() {
-        $approved_theme_slugs = $this->get_approved_theme_slugs();
-        $installed_themes     = $this->get_installed_themes();
+		return new \WP_Error(
+			$response->status,
+			'Failed to fetch installed themes.'
+		);
+	}
 
-        if( \is_wp_error( $installed_themes ) ) {
-            return $installed_themes;
-        }
+	/**
+	 * Retrieves the themes offered by the Onboarding Module.
+	 *
+	 * @return \WP_REST_RESPONSE|\WP_Error
+	 */
+	public function get_approved_themes() {
+		$approved_theme_slugs = $this->get_approved_theme_slugs();
+		$installed_themes     = $this->get_installed_themes();
 
-        foreach ( $installed_themes as $installed_theme ) {
-            if( $installed_theme->get_is_newfold_theme() 
-                || array_key_exists( $installed_theme->get_theme_name(), $approved_theme_slugs ) ) {
-                $approved_themes[] = $installed_theme;
-            }
-        }
+		if ( \is_wp_error( $installed_themes ) ) {
+			return $installed_themes;
+		}
 
-        return $approved_themes;
-    }
+		foreach ( $installed_themes as $installed_theme ) {
+			if ( $installed_theme->get_is_newfold_theme()
+				|| array_key_exists( $installed_theme->get_theme_name(), $approved_theme_slugs ) ) {
+				$approved_themes[] = $installed_theme;
+			}
+		}
 
-    /**
-     * Check permissions for routes.
-     *
-     * @return bool|\WP_Error
-     */
-    public function check_permission() {
-        return Permissions::rest_is_authorized_admin();
-    }
+		return $approved_themes;
+	}
+
+	/**
+	 * Check permissions for routes.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public function check_permission() {
+		return Permissions::rest_is_authorized_admin();
+	}
 }


### PR DESCRIPTION
Also merged changes from [add/PRESS2-23-unsplash-proxy-api](https://github.com/newfold-labs/wp-module-onboarding/pull/2)

Endpoint: https://domain.com/index.php?rest_route=/newfold-onboarding/v1/themes

As of now it only supports the "twentytwentytwo" theme along with pre-created themes by the user earlier.