### PR TITLE
Change `name` to be consistent with standards.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "wp-module-onboarding",
+    "name": "@newfold-labs/wp-module-onboarding",
     "version": "0.2.2",
     "lockfileVersion": 1,
     "requires": true,
@@ -3793,14 +3793,6 @@
                 "webpack-bundle-analyzer": "^4.4.2",
                 "webpack-cli": "^4.9.1",
                 "webpack-dev-server": "^4.4.0"
-            },
-            "dependencies": {
-                "prettier": {
-                    "version": "npm:wp-prettier@2.2.1-beta-1",
-                    "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-                    "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-                    "dev": true
-                }
             }
         },
         "@wordpress/style-engine": {
@@ -11521,6 +11513,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true
+        },
+        "prettier": {
+            "version": "npm:wp-prettier@2.2.1-beta-1",
+            "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+            "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
             "dev": true
         },
         "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "wp-module-onboarding",
+    "name": "@newfold-labs/wp-module-onboarding",
     "version": "0.2.2",
     "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
     "license": "GPL-2.0-or-later",


### PR DESCRIPTION
The `name` field for npm packages should be `@newfold-labs/wp-module-name`, even if not consumed as an npm dependency.