### PR TITLE
Update coming soon option name

### DIFF
--- a/includes/Data/Options.php
+++ b/includes/Data/Options.php
@@ -16,7 +16,7 @@ final class Options {
 	protected static $options = array(
 		'redirect'                      => 'redirect',
 		'redirect_param'                => 'redirect_param',
-		'coming_soon'                   => 'mm_coming_soon',
+		'coming_soon'                   => 'nfd_coming_soon',
 		'brand'                         => 'mm_brand',
 		'close_comments_for_old_posts'  => 'close_comments_for_old_posts',
 		'close_comments_days_old'       => 'close_comments_days_old',


### PR DESCRIPTION
We've added the coming soon module to the plugin and in the next release are changing this option name so we need it changed here as well.

See also:
https://github.com/bluehost/bluehost-wordpress-plugin/pull/245
https://github.com/bluehost/bluehost-wordpress-plugin/pull/255