### PR TITLE
Update Step Titles & Iconography

### DIFF
--- a/src/OnboardingSPA/data/routes/default-flow.js
+++ b/src/OnboardingSPA/data/routes/default-flow.js
@@ -17,6 +17,7 @@ import {
 	moveTo,
 	redo,
 	post,
+	pages as pagesIcon,
 } from '@wordpress/icons';
 import {
 	VIEW_DESIGN_COLORS,
@@ -467,7 +468,7 @@ export const steps = [
 	},
 	{
 		path: '/wp-setup/step/design/homepage-menu',
-		title: __( 'HomePages Wizard', 'wp-module-onboarding' ),
+		title: __( 'Homepage Layouts', 'wp-module-onboarding' ),
 		heading: __(
 			'There’s no place like a great home page',
 			'wp-module-onboarding'
@@ -481,7 +482,7 @@ export const steps = [
 			'wp-module-onboarding'
 		),
 		Component: StepDesignHomepageMenu,
-		Icon: header,
+		Icon: pagesIcon,
 		priority: 240,
 		VIEW: VIEW_DESIGN_HOMEPAGE_MENU,
 		patternId: 'homepage-styles',
@@ -492,8 +493,8 @@ export const steps = [
 		},
 	},
 	{
-		path: '/wp-setup/step/site-pages',
-		title: __( 'Pages', 'wp-module-onboarding' ),
+		path: '/wp-setup/step/design/site-pages',
+		title: __( 'Page Layouts', 'wp-module-onboarding' ),
 		heading: __(
 			'You have ideas, we have page templates',
 			'wp-module-onboarding'

--- a/src/OnboardingSPA/data/routes/ecommerce-flow.js
+++ b/src/OnboardingSPA/data/routes/ecommerce-flow.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { store, institution, box } from '@wordpress/icons';
+import { store, institution, shipping } from '@wordpress/icons';
 import { lazy } from '@wordpress/element';
 import { orderBy, filter } from 'lodash';
 
@@ -89,7 +89,7 @@ export const ecommerceSteps = [
 			'wp-module-onboarding'
 		),
 		Component: StepProducts,
-		Icon: box,
+		Icon: shipping,
 		priority: 95,
 		VIEW: VIEW_NAV_ECOMMERCE_STORE_INFO,
 		sidebars: {

--- a/src/OnboardingSPA/pages/Steps/SitePages/index.js
+++ b/src/OnboardingSPA/pages/Steps/SitePages/index.js
@@ -8,9 +8,9 @@ import CommonLayout from '../../../components/Layouts/Common';
 import HeadingWithSubHeading from '../../../components/HeadingWithSubHeading';
 import { getPatterns } from '../../../utils/api/patterns';
 import {
-	VIEW_NAV_PRIMARY,
 	THEME_STATUS_ACTIVE,
 	THEME_STATUS_NOT_ACTIVE,
+	VIEW_NAV_DESIGN,
 } from '../../../../constants';
 import { DesignStateHandler } from '../../../components/StateHandlers';
 import {
@@ -55,7 +55,7 @@ const StepSitePages = () => {
 			setIsDrawerOpened( false );
 		}
 		setIsSidebarOpened( false );
-		setDrawerActiveView( VIEW_NAV_PRIMARY );
+		setDrawerActiveView( VIEW_NAV_DESIGN );
 		setIsHeaderNavigationEnabled( true );
 	}, [] );
 


### PR DESCRIPTION
* `HomePages Wizard` string to `Homepage Layouts`
* Use new `pagesIcon` for Homepage step.
* `Pages` to `Page Layouts`
* Update Product Icon to better match.