### PR TITLE
Use white text for selected color palette text label

### DIFF
--- a/src/OnboardingSPA/components/Drawer/stylesheet.scss
+++ b/src/OnboardingSPA/components/Drawer/stylesheet.scss
@@ -385,6 +385,9 @@ $main-border-main--rgb: var(--nfd-onboarding-highlighted--rgb);
 
 	&-selected {
 		background-color: $main-border-main;
+		.color-palette__name {
+			color: var(--nfd-onboarding-light);
+		}
 	}
 
 	&__colors {


### PR DESCRIPTION
Use white text for selection state on color palettes.