### PR TITLE
Remove trailing commas in function calls.

### DIFF
--- a/includes/Data/Plugins.php
+++ b/includes/Data/Plugins.php
@@ -241,7 +241,7 @@ final class Plugins {
 	public static function get_squashed() {
 		return array_merge(
 			array_filter( self::$wp_slugs, array( __CLASS__, 'check_approved' ) ) ,
-			array_filter( self::$nfd_slugs, array( __CLASS__, 'check_approved' ) ) ,
+			array_filter( self::$nfd_slugs, array( __CLASS__, 'check_approved' ) )
 		);
 	}
 

--- a/includes/RestApi/PluginsController.php
+++ b/includes/RestApi/PluginsController.php
@@ -306,13 +306,13 @@ class PluginsController {
 				PluginInstallTaskManager::add_to_queue(
 					new PluginInstallTask(
 						$plugin,
-						true,
+						true
 					)
 				);
 			} else {
 				PluginUninstallTaskManager::add_to_queue(
 					new PluginUninstallTask(
-						$plugin,
+						$plugin
 					)
 				);
 			}

--- a/includes/RestApi/Themes/ThemeVariationsController.php
+++ b/includes/RestApi/Themes/ThemeVariationsController.php
@@ -136,7 +136,7 @@ class ThemeVariationsController extends \WP_REST_Controller {
 
 		return array_merge(
 			array( $active_variation_global_style ),
-			self::get_style_variations(),
+			self::get_style_variations()
 		);
 	}
 

--- a/includes/TaskManagers/PluginUninstallTaskManager.php
+++ b/includes/TaskManagers/PluginUninstallTaskManager.php
@@ -114,9 +114,9 @@ class PluginUninstallTaskManager {
 		$position_in_queue = PluginInstallTaskManager::status( $plugin_uninstall_task->get_slug() );
 		if ( $position_in_queue !== false && $position_in_queue !== 0 ) {
 			PluginInstallTaskManager::remove_from_queue(
-				$plugin_uninstall_task->get_slug(),
+				$plugin_uninstall_task->get_slug()
 			);
-			
+
 			return true;
 		}
 


### PR DESCRIPTION
Remove trailing commas in function calls. Triggers a fatal error in PHP < 7.3