### PR TITLE
Handle module disabling on prod

### DIFF
--- a/includes/Data/Data.php
+++ b/includes/Data/Data.php
@@ -2,7 +2,7 @@
 namespace NewfoldLabs\WP\Module\Onboarding\Data;
 
 use NewfoldLabs\WP\Module\Onboarding\Permissions;
-use Bluehost\WP\Data\Customer;
+use NewfoldLabs\WP\Module\CustomerBluehost\CustomerBluehost;
 
 /**
  * CRUD methods for Onboarding config for use in API, CLI and runtime.
@@ -103,8 +103,8 @@ final class Data {
 	 * @return array
 	 */
 	public static function customer_data() {
-		if ( class_exists( 'Bluehost\WP\Data\Customer' ) ) {
-			 return Customer::collect();
+		if ( class_exists( 'NewfoldLabs\WP\Module\CustomerBluehost\CustomerBluehost' ) ) {
+			 return CustomerBluehost::collect();
 		}
 		 return array();
 	}


### PR DESCRIPTION
Onboarding was not working on prod with the latest build, the reason being that this plugin release also switches from https://github.com/bluehost/bluehost-wp-customer-data to https://github.com/newfold-labs/wp-module-customer-bluehost. This PR modifies onboarding to use the new customer data module.