### PR TITLE
Improve plugin status detection

### DIFF
--- a/includes/RestApi/PluginsController.php
+++ b/includes/RestApi/PluginsController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NewfoldLabs\WP\Module\Onboarding\RestApi;
 
+use NewfoldLabs\WP\Module\Onboarding\Data\Options;
 use NewfoldLabs\WP\Module\Onboarding\Permissions;
 use NewfoldLabs\WP\Module\Onboarding\Data\Plugins;
 use NewfoldLabs\WP\Module\Onboarding\Data\SiteFeatures;
@@ -277,6 +278,17 @@ class PluginsController {
 				array(
 					'status'   => 'installing',
 					'estimate' => ( ( $position_in_queue + 1 ) * 30 ),
+				),
+				200
+			);
+		}
+
+		$in_progress_plugin = \get_option( Options::get_option_name( 'plugins_init_status' ), '' );
+		if ( $in_progress_plugin === $plugin ) {
+			return new \WP_REST_Response(
+				array(
+					'status'   => 'installing',
+					'estimate' => 30,
 				),
 				200
 			);


### PR DESCRIPTION
When plugin installation is in progress via the WP_Cron and the plugin directory is in a half-baked state, Onboarding is unable to determine if the plugin has been installed or not, causing it to default to a not installed state. This PR checks if a plugin is being installed and then waits for the installation task to complete before defaulting to the not installed state.