### PR TITLE
Remove unnecessary redirect transient update

### DIFF
--- a/includes/ModuleController.php
+++ b/includes/ModuleController.php
@@ -41,9 +41,6 @@ class ModuleController {
 			// Check if the Module Does Exist
 			if ( ModuleRegistry::get( $module_name ) ) {
 
-				// Disable the Redirect for Onboarding SPA
-				LoginRedirect::disable_redirect();
-
 				// Deactivate the Module
 				deactivate( $module_name );
 			}


### PR DESCRIPTION
The redirect transient was updating on every page load even after the fix we did in 1.4.0 because the `enable_redirect` code that we removed when improving the efficiency of `ModuleController` solved the transient update issue only when a site met the onboarding criteria.

This PR removes the unnecessary `disable_redirect` call that runs whenever a site does not meet the criteria for Onboarding, in this case the module disables itself, preventing a login redirect, and we do not need to manually set a transient (this is the edge case we need to test whenever performing QA).