### PR TITLE
Add redirect for SSO logins

### DIFF
--- a/includes/Application.php
+++ b/includes/Application.php
@@ -55,7 +55,8 @@ final class Application {
 		// Reset the stored Compatibility Status every time WP Core is updated.
 		\add_action( '_core_updated_successfully', array( Status::class, 'reset' ) );
 
-		\add_action( 'login_redirect', array( LoginRedirect::class, 'handle_redirect' ), 10, 3 );
+		\add_filter( 'login_redirect', array( LoginRedirect::class, 'handle_redirect' ), 10 );
+		\add_filter( 'newfold_sso_success_url', array( LoginRedirect::class, 'handle_redirect' ), 10 );
 		\add_filter(
 			Options::get_option_name( 'redirect' ) . '_disable',
 			array( LoginRedirect::class, 'remove_handle_redirect_action' )

--- a/includes/LoginRedirect.php
+++ b/includes/LoginRedirect.php
@@ -16,6 +16,11 @@ class LoginRedirect {
 	 * @return string
 	 */
 	public static function handle_redirect( $original_redirect ) {
+		// Don't redirect if user is not an admin
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return $original_redirect;
+		}
+
 		$redirect_option_name = Options::get_option_name( 'redirect' );
 		// If request has ?nfd_module_onboarding_redirect=false then temporarily disable the redirect
 		if ( isset( $_GET[ $redirect_option_name ] )
@@ -58,12 +63,8 @@ class LoginRedirect {
 			return $original_redirect;
 		}
 
-		// Finally, if we made it this far, then set the redirect URL to point to onboarding if the user is an admin
-		if ( current_user_can( 'manage_options' ) ) {
-			return \admin_url( '/index.php?page=nfd-onboarding' );
-		}
-
-		return $original_redirect;
+		// Finally, if we made it this far, then set the redirect URL to point to onboarding
+		return \admin_url( '/index.php?page=nfd-onboarding' );
 	}
 
 	/**

--- a/includes/LoginRedirect.php
+++ b/includes/LoginRedirect.php
@@ -12,10 +12,10 @@ class LoginRedirect {
 	/**
 	 * Handles the redirect to onboarding
 	 *
-	 * @param string $redirect The requested redirect URL
+	 * @param string $original_redirect The requested redirect URL
 	 * @return string
 	 */
-	public static function handle_redirect( $redirect ) {
+	public static function handle_redirect( $original_redirect ) {
 		$redirect_option_name = Options::get_option_name( 'redirect' );
 		// If request has ?nfd_module_onboarding_redirect=false then temporarily disable the redirect
 		if ( isset( $_GET[ $redirect_option_name ] )
@@ -25,18 +25,18 @@ class LoginRedirect {
 
 		// Redirect was temporarily disabled via transient
 		if ( \get_transient( Options::get_option_name( 'redirect_param' ) ) === '1' ) {
-			return $redirect;
+			return $original_redirect;
 		}
 
 		// Don't redirect if coming soon is off. User has launched their site
 		if ( \get_option( Options::get_option_name( 'coming_soon', false ), 'true' ) !== 'true' ) {
-			return $redirect;
+			return $original_redirect;
 		}
 
 		// Don't redirect if they have intentionally exited or completed onboarding
 		$flow_data = \get_option( Options::get_option_name( 'flow' ), false );
 		if ( data_get( $flow_data, 'hasExited' ) || data_get( $flow_data, 'isComplete' ) ) {
-			return $redirect;
+			return $original_redirect;
 		}
 
 		// Check for disabled redirect database option: nfd_module_onboarding_redirect
@@ -46,7 +46,7 @@ class LoginRedirect {
 			$redirect_option = \update_option( $redirect_option_name, true );
 		}
 		if ( ! $redirect_option ) {
-			return $redirect;
+			return $original_redirect;
 		}
 
 		// If site was created more than 72 hours ago, don't redirect to onboarding
@@ -55,7 +55,7 @@ class LoginRedirect {
 		$interval          = $current_date->diff( $install_date );
 		$interval_in_hours = ( $interval->days * 24 ) + $interval->h;
 		if ( $interval_in_hours >= 72 ) {
-			return $redirect;
+			return $original_redirect;
 		}
 
 		// Finally, if we made it this far, then set the redirect URL to point to onboarding if the user is an admin
@@ -63,7 +63,7 @@ class LoginRedirect {
 			return \admin_url( '/index.php?page=nfd-onboarding' );
 		}
 
-		return $redirect;
+		return $original_redirect;
 	}
 
 	/**

--- a/includes/LoginRedirect.php
+++ b/includes/LoginRedirect.php
@@ -19,8 +19,8 @@ class LoginRedirect {
 		$redirect_option_name = Options::get_option_name( 'redirect' );
 		// If request has ?nfd_module_onboarding_redirect=false then temporarily disable the redirect
 		if ( isset( $_GET[ $redirect_option_name ] )
-		  && 'false' === $_GET[ $redirect_option_name ] ) {
-			 self::disable_redirect();
+			&& 'false' === $_GET[ $redirect_option_name ] ) {
+			self::disable_redirect();
 		}
 
 		// Redirect was temporarily disabled via transient
@@ -45,7 +45,7 @@ class LoginRedirect {
 		if ( empty( $redirect_option ) ) {
 			$redirect_option = \update_option( $redirect_option_name, true );
 		}
-		if (! $redirect_option) {
+		if ( ! $redirect_option ) {
 			return $redirect;
 		}
 
@@ -55,12 +55,12 @@ class LoginRedirect {
 		$interval          = $current_date->diff( $install_date );
 		$interval_in_hours = ( $interval->days * 24 ) + $interval->h;
 		if ( $interval_in_hours >= 72 ) {
-			 return $redirect;
+			return $redirect;
 		}
 
 		// Finally, if we made it this far, then set the redirect URL to point to onboarding if the user is an admin
 		if ( ! current_user_can( 'manage_options' ) ) {
-			 return \admin_url( '/index.php?page=nfd-onboarding' );
+			return \admin_url( '/index.php?page=nfd-onboarding' );
 		}
 
 		return $redirect;
@@ -72,7 +72,7 @@ class LoginRedirect {
 	 * @return void
 	 */
 	public static function disable_redirect() {
-		  \set_transient( Options::get_option_name( 'redirect_param' ), '1', 30 );
+		\set_transient( Options::get_option_name( 'redirect_param' ), '1', 30 );
 	}
 
 	/**
@@ -81,7 +81,7 @@ class LoginRedirect {
 	 * @return void
 	 */
 	public static function enable_redirect() {
-		  \set_transient( Options::get_option_name( 'redirect_param' ), '0', 30 );
+		\set_transient( Options::get_option_name( 'redirect_param' ), '0', 30 );
 	}
 
 	/**
@@ -90,6 +90,6 @@ class LoginRedirect {
 	 * @return bool
 	 */
 	public static function remove_handle_redirect_action() {
-		 return \remove_action( 'login_redirect', array( __CLASS__, 'handle_redirect' ) );
+		return \remove_action( 'login_redirect', array( __CLASS__, 'handle_redirect' ) );
 	}
 }

--- a/includes/LoginRedirect.php
+++ b/includes/LoginRedirect.php
@@ -59,7 +59,7 @@ class LoginRedirect {
 		}
 
 		// Finally, if we made it this far, then set the redirect URL to point to onboarding if the user is an admin
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( current_user_can( 'manage_options' ) ) {
 			return \admin_url( '/index.php?page=nfd-onboarding' );
 		}
 

--- a/includes/LoginRedirect.php
+++ b/includes/LoginRedirect.php
@@ -12,49 +12,54 @@ class LoginRedirect {
 	/**
 	 * Handles the redirect to onboarding
 	 *
-	 * @param [type] $redirect The requested redirect URL.
-	 * @param [type] $redirect_to The requested redirect URL via param.
-	 * @param [type] $user The logged in user object.
+	 * @param string $redirect The requested redirect URL
 	 * @return string
 	 */
-	public static function handle_redirect( $redirect, $redirect_to, $user ) {
+	public static function handle_redirect( $redirect ) {
 		$redirect_option_name = Options::get_option_name( 'redirect' );
+		// If request has ?nfd_module_onboarding_redirect=false then temporarily disable the redirect
 		if ( isset( $_GET[ $redirect_option_name ] )
 		  && 'false' === $_GET[ $redirect_option_name ] ) {
 			 self::disable_redirect();
 		}
 
-		$flow_exited    = false;
-		$flow_completed = false;
-		$flow_data      = \get_option( Options::get_option_name( 'flow' ), false );
-		if ( ! empty( $flow_data ) ) {
-			$flow_exited    = ( ! empty( $flow_data['hasExited'] ) );
-			$flow_completed = ( ! empty( $flow_data['isComplete'] ) );
-		}
-
-		if ( \get_transient( Options::get_option_name( 'redirect_param' ) ) === '1'
-		 || $flow_exited
-		 || $flow_completed
-		 ) {
+		// Redirect was temporarily disabled via transient
+		if ( \get_transient( Options::get_option_name( 'redirect_param' ) ) === '1' ) {
 			return $redirect;
 		}
 
+		// Don't redirect if coming soon is off. User has launched their site
+		if ( \get_option( Options::get_option_name( 'coming_soon', false ), 'true' ) !== 'true' ) {
+			return $redirect;
+		}
+
+		// Don't redirect if they have intentionally exited or completed onboarding
+		$flow_data = \get_option( Options::get_option_name( 'flow' ), false );
+		if ( data_get( $flow_data, 'hasExited' ) || data_get( $flow_data, 'isComplete' ) ) {
+			return $redirect;
+		}
+
+		// Check for disabled redirect database option: nfd_module_onboarding_redirect
 		$redirect_option = \get_option( $redirect_option_name, null );
+		// If not set, then set it to true
 		if ( empty( $redirect_option ) ) {
 			$redirect_option = \update_option( $redirect_option_name, true );
 		}
+		if (! $redirect_option) {
+			return $redirect;
+		}
+
+		// If site was created more than 72 hours ago, don't redirect to onboarding
 		$install_date      = new DateTime( \get_option( Options::get_option_name( 'install_date', false ), gmdate( 'M d, Y' ) ) );
 		$current_date      = new DateTime( gmdate( 'M d, Y' ) );
 		$interval          = $current_date->diff( $install_date );
 		$interval_in_hours = ( $interval->days * 24 ) + $interval->h;
-
-		if ( ! ( $redirect_option
-		&& \get_option( Options::get_option_name( 'coming_soon', false ), 'true' ) === 'true'
-		&& ( $interval_in_hours <= 72 ) ) ) {
+		if ( $interval_in_hours >= 72 ) {
 			 return $redirect;
 		}
 
-		if ( self::is_administrator( $user ) ) {
+		// Finally, if we made it this far, then set the redirect URL to point to onboarding if the user is an admin
+		if ( ! current_user_can( 'manage_options' ) ) {
 			 return \admin_url( '/index.php?page=nfd-onboarding' );
 		}
 

--- a/includes/LoginRedirect.php
+++ b/includes/LoginRedirect.php
@@ -66,28 +66,6 @@ class LoginRedirect {
 		return $redirect;
 	}
 
-	 /**
-	  * Check if we have a valid user.
-	  *
-	  * @param \WP_User $user The WordPress user object.
-	  *
-	  * @return bool
-	  */
-	public static function is_user( $user ) {
-		return $user && is_object( $user ) && is_a( $user, 'WP_User' );
-	}
-
-	/**
-	 * Check if a user is an administrator.
-	 *
-	 * @param \WP_User $user WordPress user.
-	 *
-	 * @return bool
-	 */
-	public static function is_administrator( $user ) {
-		return self::is_user( $user ) && $user->has_cap( Permissions::ADMIN );
-	}
-
 	/**
 	 * Sets a transient that disables redirect to onboarding on login.
 	 *


### PR DESCRIPTION
The automatic redirect logic currently only works for a direct WordPress login. This PR adds the auto-redirect functionality to SSO logins, so that the hosting platforms do not need to handle deciding whether to send a user into onboarding by passing URL parameters. 

I also cleaned up the logic inside this method so it is easier to read and understand, and removed some overly abstracted permissions checks. Early returns after each successive check reduces possible DB queries when the redirect is not needed. 

## Other Notes
The module does a lot of work right now in determining onboarding eligibility and disabling itself outside of this redirect. I would prefer it not disable itself until after onboarding is completed, but rather just short-circuit the logic and do nothing. It made it very difficult to test this locally because of all the checks. Keeping the module active makes it easier to allow onboarding to be resumed or done at any time. Future improvements on this functionality could utilize the new site capabilities API from Hiive. That work should be done in a different PR though to keep this one lean and focused. 