### PR TITLE
Split out redirect filters into separate methods

### DIFF
--- a/includes/Application.php
+++ b/includes/Application.php
@@ -55,8 +55,8 @@ final class Application {
 		// Reset the stored Compatibility Status every time WP Core is updated.
 		\add_action( '_core_updated_successfully', array( Status::class, 'reset' ) );
 
-		\add_filter( 'login_redirect', array( LoginRedirect::class, 'handle_redirect' ), 10 );
-		\add_filter( 'newfold_sso_success_url', array( LoginRedirect::class, 'handle_redirect' ), 10 );
+		\add_filter( 'login_redirect', array( LoginRedirect::class, 'wplogin' ), 10, 3 );
+		\add_filter( 'newfold_sso_success_url', array( LoginRedirect::class, 'sso' ), 10 );
 		\add_filter(
 			Options::get_option_name( 'redirect' ) . '_disable',
 			array( LoginRedirect::class, 'remove_handle_redirect_action' )

--- a/includes/LoginRedirect.php
+++ b/includes/LoginRedirect.php
@@ -14,32 +14,32 @@ class LoginRedirect {
 	 * @param string $original_redirect The requested redirect URL
 	 * @return string The filtered url to redirect to
 	 */
-    public static function sso( $original_redirect ) {
-        return self::filter_redirect( $original_redirect, wp_get_current_user() );
-    }
+	public static function sso( $original_redirect ) {
+		return self::filter_redirect( $original_redirect, wp_get_current_user() );
+	}
 
 	/**
 	 * Redirect hook for direct WP Logins
 	 *
-	 * @param string $original_redirect
-	 * @param string $requested_original_redirect
-	 * @param WP_User|WP_Error $user
+	 * @param string $original_redirect           The requested redirect URL
+	 * @param string           $requested_original_redirect The requested redirect URL from parameter
+	 * @param WP_User|WP_Error $user              The current logged in user or WP_Error on login failure
 	 * @return string The filtered URL to redirect to
 	 */
-    public static function wplogin( $original_redirect, $requested_original_redirect, $user ) {
+	public static function wplogin( $original_redirect, $requested_original_redirect, $user ) {
 		// wp-login.php runs this filter on load and login failures
 		// We should only do a redirect with a succesful user login
 		if ( ! ( $user instanceof \WP_User ) ) {
 			return $original_redirect;
 		}
-        return self::filter_redirect( $original_redirect, $user );
-    }
+		return self::filter_redirect( $original_redirect, $user );
+	}
 
 	/**
 	 * Evaluate whether the redirect should point to onboarding
 	 *
-	 * @param string $original_redirect The requested redirect URL
-	 * @param WP_User $user The logged in user
+	 * @param string  $original_redirect The requested redirect URL
+	 * @param WP_User $user              The logged in user
 	 * @return string The filtered url to redirect to
 	 */
 	public static function filter_redirect( $original_redirect, $user ) {

--- a/includes/LoginRedirect.php
+++ b/includes/LoginRedirect.php
@@ -21,9 +21,9 @@ class LoginRedirect {
 	/**
 	 * Redirect hook for direct WP Logins
 	 *
-	 * @param string $original_redirect           The requested redirect URL
+	 * @param string           $original_redirect           The requested redirect URL
 	 * @param string           $requested_original_redirect The requested redirect URL from parameter
-	 * @param WP_User|WP_Error $user              The current logged in user or WP_Error on login failure
+	 * @param WP_User|WP_Error $user                        The current logged in user or WP_Error on login failure
 	 * @return string The filtered URL to redirect to
 	 */
 	public static function wplogin( $original_redirect, $requested_original_redirect, $user ) {


### PR DESCRIPTION
The `login_redirect` filter and the `newfold_sso_success_url` filters accept differing numbers of parameters. They also require different ways of determining the current user. The former does not have `$current_user` set and the latter does not have a `$user` global variable.

To make them both work correctly, and avoid a lot of logic to check values and types of multiple variables, I've created separate methods for each hook that each establish the logged in user, and then pass the url and user on to a single `filter_redirect` method for evaluation.