### PR TITLE
Fix Site Pages Analytics condition

### DIFF
--- a/src/OnboardingSPA/components/App/index.js
+++ b/src/OnboardingSPA/components/App/index.js
@@ -246,9 +246,14 @@ const App = () => {
 		}
 
 		if ( previousStep.includes( 'site-pages' ) ) {
-			currentData.data.sitePages?.other?.forEach( ( sitePage ) => {
-				trackHiiveEvent( `${ sitePage.slug }-layout`, sitePage.slug );
-			} );
+			if ( currentData.data.sitePages?.other !== false ) {
+				currentData.data.sitePages?.other?.forEach( ( sitePage ) => {
+					trackHiiveEvent(
+						`${ sitePage.slug }-layout`,
+						sitePage.slug
+					);
+				} );
+			}
 		}
 
 		if ( previousStep.includes( 'site-features' ) ) {


### PR DESCRIPTION
In case the user doesn't select any option in the Site pages step the value is saved as false.

Currently getting this error and it crashes on Site Features
<img width="380" alt="Screenshot 2023-06-06 at 10 02 05 PM" src="https://github.com/newfold-labs/wp-module-onboarding/assets/48691514/1e243d27-b05a-4862-adf9-21f28692185d">
