### PR TITLE
Palette Mapping and Custom to Predefined Palette fix

### DIFF
--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
@@ -233,13 +233,7 @@ const DesignColors = () => {
 			return true;
 		}
 
-		const customColorsTemp = customColors;
-		for ( const custom in customColorsTemp ) {
-			customColorsTemp[ custom ] = '';
-		}
-
-		// Setting the color palette to the chosen predefined color.
-		setCustomColors( customColorsTemp );
+		clearCustomColors();
 		saveThemeColorPalette( colorStyle );
 		setSelectedColorsLocal( colorPalettes[ colorStyle ] );
 		LocalToState( colorPalettes[ colorStyle ], colorStyle );
@@ -294,18 +288,23 @@ const DesignColors = () => {
 			useGlobalStylesOutput( selectedGlobalStyle, storedPreviewSettings )
 		);
 
-		for ( const colorVal in selectedColors ) {
-			selectedColors[ colorVal ].color = '';
-		}
-
-		// Resetting the color palette to default and unsetting the selected predefined color palette, if any.
-		setCustomColors( selectedColors );
+		clearCustomColors();
 
 		const selectedGlobalStylePalette =
 			selectedGlobalStyle.settings.color.palette;
 		setSelectedColors( selectedGlobalStylePalette );
 		setSelectedColorsLocal( stateToLocal( selectedGlobalStylePalette ) );
 		trackHiiveEvent( 'color-selection-reset', selectedGlobalStyle.title );
+	}
+
+	async function clearCustomColors() {
+		const customColorsTemp = customColors;
+		for ( const custom in customColorsTemp ) {
+			customColorsTemp[ custom ] = '';
+		}
+
+		// Resetting the color palette to default and unsetting the selected predefined color palette, if any.
+		setCustomColors( customColorsTemp );
 	}
 
 	async function resetColors() {
@@ -336,7 +335,7 @@ const DesignColors = () => {
 						<div
 							className="color-palette__colors--tertiary"
 							style={ {
-								backgroundColor: `${ colorPalettes[ colorStyle ]?.tertiary }`,
+								backgroundColor: `${ colorPalettes[ colorStyle ]?.['header-background'] }`,
 							} }
 						/>
 						<div

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
@@ -373,15 +373,15 @@ const DesignColors = () => {
 		const defaultColor = '#fff';
 		const primaryColorTemp =
 			customColors && customColors?.primary !== ''
-				? customColors?.primary
+				? customColors.primary
 				: selectedColorsLocal?.primary ?? defaultColor;
 		const secondaryColorTemp =
 			customColors && customColors?.secondary !== ''
-				? customColors?.secondary
+				? customColors.secondary
 				: selectedColorsLocal?.secondary ?? defaultColor;
 		const tertiaryColorTemp =
 			customColors && customColors?.[ 'header-background' ] !== ''
-				? customColors?.[ 'header-background' ]
+				? customColors[ 'header-background' ]
 				: selectedColorsLocal?.[ 'header-background' ] ?? defaultColor;
 		const paletteCount = Object.keys( colorPalettes ).length;
 

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
@@ -47,6 +47,7 @@ const DesignColors = () => {
 		if ( selectedColorPalette ) {
 			const selectedColorsLocalTemp = {};
 			selectedColorPalette?.forEach( ( color ) => {
+				console.log(selectedColorPalette);
 				selectedColorsLocalTemp[ color.slug ] = color.color;
 			} );
 			setSelectedColorsLocal( selectedColorsLocalTemp );
@@ -233,7 +234,13 @@ const DesignColors = () => {
 			return true;
 		}
 
-		setCustomColors();
+		const customColorsTemp = customColors;
+		for ( const custom in customColorsTemp ) {
+			customColorsTemp[ custom ] = '';
+		}
+
+		// Setting the color palette to the chosen predefined color.
+		setCustomColors( customColorsTemp );
 		saveThemeColorPalette( colorStyle );
 		setSelectedColorsLocal( colorPalettes[ colorStyle ] );
 		LocalToState( colorPalettes[ colorStyle ], colorStyle );
@@ -292,7 +299,8 @@ const DesignColors = () => {
 			selectedColors[ colorVal ].color = '';
 		}
 
-		setCustomColors();
+		// Resetting the color palette to default and unsetting the selected predefined color palette, if any.
+		setCustomColors( selectedColors );
 
 		const selectedGlobalStylePalette =
 			selectedGlobalStyle.settings.color.palette;

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
@@ -381,7 +381,7 @@ const DesignColors = () => {
 				: selectedColorsLocal?.secondary ?? defaultColor;
 		const tertiaryColorTemp =
 			customColors && customColors?.tertiary !== ''
-				? customColors?.tertiary
+				? customColors?.['header-background']
 				: selectedColorsLocal?.[ 'header-background' ] ?? defaultColor;
 		const paletteCount = Object.keys( colorPalettes ).length;
 

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
@@ -233,12 +233,7 @@ const DesignColors = () => {
 			return true;
 		}
 
-		const customColorsTemp = customColors;
-		for ( const custom in customColorsTemp ) {
-			customColorsTemp[ custom ] = '';
-		}
-
-		setCustomColors( customColorsTemp );
+		setCustomColors();
 		saveThemeColorPalette( colorStyle );
 		setSelectedColorsLocal( colorPalettes[ colorStyle ] );
 		LocalToState( colorPalettes[ colorStyle ], colorStyle );

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
@@ -335,7 +335,7 @@ const DesignColors = () => {
 						<div
 							className="color-palette__colors--tertiary"
 							style={ {
-								backgroundColor: `${ colorPalettes[ colorStyle ]?.['header-background'] }`,
+								backgroundColor: `${ colorPalettes[ colorStyle ]?.[ 'header-background' ] }`,
 							} }
 						/>
 						<div

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
@@ -297,14 +297,13 @@ const DesignColors = () => {
 		trackHiiveEvent( 'color-selection-reset', selectedGlobalStyle.title );
 	}
 
-	async function clearCustomColors() {
-		const customColorsTemp = customColors;
-		for ( const custom in customColorsTemp ) {
-			customColorsTemp[ custom ] = '';
+	function clearCustomColors() {
+		for ( const custom in customColors ) {
+			customColors[ custom ] = '';
 		}
 
 		// Resetting the color palette to default and unsetting the selected predefined color palette, if any.
-		setCustomColors( customColorsTemp );
+		setCustomColors( customColors );
 	}
 
 	async function resetColors() {
@@ -381,7 +380,7 @@ const DesignColors = () => {
 				? customColors?.secondary
 				: selectedColorsLocal?.secondary ?? defaultColor;
 		const tertiaryColorTemp =
-			customColors && customColors?.tertiary !== ''
+			customColors && customColors?.[ 'header-background' ] !== ''
 				? customColors?.[ 'header-background' ]
 				: selectedColorsLocal?.[ 'header-background' ] ?? defaultColor;
 		const paletteCount = Object.keys( colorPalettes ).length;

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
@@ -202,10 +202,10 @@ const DesignColors = () => {
 			if ( currentData?.data?.colorStyle === 'custom' ) {
 				setCustomColors( selectedColorsLocalTemp );
 			}
+			setSelectedColors( selectedColorPalette );
 		} else {
 			setToDefaultPalette();
 		}
-		setSelectedColors( selectedColorPalette );
 		saveThemeColorPalette(
 			currentData?.data?.colorStyle,
 			colorPaletteResponse?.body.tailored,
@@ -233,6 +233,12 @@ const DesignColors = () => {
 			return true;
 		}
 
+		const customColorsTemp = customColors;
+		for ( const custom in customColorsTemp ) {
+			customColorsTemp[ custom ] = '';
+		}
+
+		setCustomColors( customColorsTemp );
 		saveThemeColorPalette( colorStyle );
 		setSelectedColorsLocal( colorPalettes[ colorStyle ] );
 		LocalToState( colorPalettes[ colorStyle ], colorStyle );
@@ -376,7 +382,7 @@ const DesignColors = () => {
 		const tertiaryColorTemp =
 			customColors && customColors?.tertiary !== ''
 				? customColors?.tertiary
-				: selectedColorsLocal?.tertiary ?? defaultColor;
+				: selectedColorsLocal?.[ 'header-background' ] ?? defaultColor;
 		const paletteCount = Object.keys( colorPalettes ).length;
 
 		return (

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
@@ -47,7 +47,6 @@ const DesignColors = () => {
 		if ( selectedColorPalette ) {
 			const selectedColorsLocalTemp = {};
 			selectedColorPalette?.forEach( ( color ) => {
-				console.log(selectedColorPalette);
 				selectedColorsLocalTemp[ color.slug ] = color.color;
 			} );
 			setSelectedColorsLocal( selectedColorsLocalTemp );

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignColors.js
@@ -381,7 +381,7 @@ const DesignColors = () => {
 				: selectedColorsLocal?.secondary ?? defaultColor;
 		const tertiaryColorTemp =
 			customColors && customColors?.tertiary !== ''
-				? customColors?.['header-background']
+				? customColors?.[ 'header-background' ]
 				: selectedColorsLocal?.[ 'header-background' ] ?? defaultColor;
 		const paletteCount = Object.keys( colorPalettes ).length;
 


### PR DESCRIPTION
Bugs resolved:
- Tertiary shade in color palette mapped correctly to the theme preview
- After choosing a custom color, if a pre-defined palette is chosen, the color palette gets mapped to the chosen color