### PR TITLE
Fix newfold card logo popping up on safari

### DIFF
--- a/src/OnboardingSPA/components/NewfoldLargeCard/index.js
+++ b/src/OnboardingSPA/components/NewfoldLargeCard/index.js
@@ -1,10 +1,12 @@
-import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 
-const NewfoldLargeCard = ({ className = '', children }) => {
+const NewfoldLargeCard = ( { className = '', children } ) => {
+	const finalClassName = classNames( 'nfd-onboarding-large-card', className );
+
 	return (
-		<div className={classNames('nfd-onboarding-large-card', className)}>
-			{children}
+		<div className={ finalClassName }>
+			<div className={ `${ finalClassName }__logo` }></div>
+			{ children }
 		</div>
 	);
 };

--- a/src/OnboardingSPA/components/NewfoldLargeCard/index.js
+++ b/src/OnboardingSPA/components/NewfoldLargeCard/index.js
@@ -1,11 +1,9 @@
 import classNames from 'classnames';
 
 const NewfoldLargeCard = ( { className = '', children } ) => {
-	const finalClassName = classNames( 'nfd-onboarding-large-card', className );
-
 	return (
-		<div className={ finalClassName }>
-			<div className={ `${ finalClassName }__logo` }></div>
+		<div className={ classNames( 'nfd-onboarding-large-card', className ) }>
+			<div className={ `nfd-onboarding-large-card__logo` }></div>
 			{ children }
 		</div>
 	);

--- a/src/OnboardingSPA/components/NewfoldLargeCard/stylesheet.scss
+++ b/src/OnboardingSPA/components/NewfoldLargeCard/stylesheet.scss
@@ -19,7 +19,7 @@
 		transform-style: flat;
 	}
 
-	&::before {
+	&__logo {
 		content: "";
 		background: var(--nfd-onboarding-contrast-icon) no-repeat;
 		width: 600px;
@@ -37,14 +37,14 @@
 		padding: 20px;
 		margin: 30px;
 
-		&::before {
+		&__logo {
 			display: none;
 		}
 	}
 
 	@media (min-width: #{ ($break-medium) }) and (max-width: 1300px) {
 
-		&::before {
+		&__logo {
 			width: 400px;
 			height: 350px;
 			left: -10.5rem;
@@ -56,7 +56,7 @@
 		width: 50vw;
 		min-height: 960px;
 
-		&::before {
+		&__logo {
 			width: 860px;
 			min-height: 600px;
 			left: -19rem;


### PR DESCRIPTION
This one uses an actual HTML element`div` with the background instead of `::before`.