### PR TITLE
Use installer API for theme status

### DIFF
--- a/src/OnboardingSPA/utils/api/themes.js
+++ b/src/OnboardingSPA/utils/api/themes.js
@@ -60,7 +60,7 @@ const setGlobalStyles = async ( data ) => {
 const getThemeStatus = async ( theme ) => {
 	return await resolve(
 		apiFetch( {
-			url: onboardingRestURL(
+			url: installerRestURL(
 				'themes/status' + ( theme ? `&theme=${ theme }` : '' )
 			),
 		} )


### PR DESCRIPTION
This API doesn't exist in Onboarding now, so this call returns a 404, we have fallbacks in place that throw a dialog to confirm the theme switch, but it's not right to throw the dialog since Wonder should already be active at that point.
![Screenshot 2023-07-07 at 2 32 22 PM](https://github.com/newfold-labs/wp-module-onboarding/assets/38878906/26d440da-50ec-4e5c-bb94-7b05b283fb4a)
