### PR TITLE
Expedite theme install if wp-cron fails to install in time

### DIFF
--- a/src/OnboardingSPA/components/ExitToWordPress/index.js
+++ b/src/OnboardingSPA/components/ExitToWordPress/index.js
@@ -19,6 +19,7 @@ import {
 	ACTION_ONBOARDING_EXITED,
 	CATEGORY,
 } from '../../utils/analytics/hiive/constants';
+import { activateInitialPlugins } from '../../utils/api/plugins';
 
 /**
  * Self-contained button and confirmation modal for exiting Onboarding page.
@@ -101,6 +102,7 @@ const ExitToWordPress = ( {
 			}
 			setFlow( currentData );
 		}
+		activateInitialPlugins();
 		trackOnboardingEvent(
 			new OnboardingEvent( ACTION_ONBOARDING_EXITED, currentStep.title )
 		);

--- a/src/OnboardingSPA/components/StateHandlers/Design/index.js
+++ b/src/OnboardingSPA/components/StateHandlers/Design/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { StepLoader } from '../../Loaders';
 import { store as nfdOnboardingStore } from '../../../store';
 import {
+	expedite,
 	getThemeStatus,
 	install as installTheme,
 } from '../../../utils/api/themes';
@@ -15,7 +16,6 @@ import {
 	THEME_STATUS_NOT_ACTIVE,
 	THEME_STATUS_ACTIVE,
 	DESIGN_STEPS_THEME,
-	THEME_INSTALL_WAIT_TIMEOUT,
 	THEME_STATUS_FAILURE,
 } from '../../../../constants';
 import { StepErrorState } from '../../ErrorState';
@@ -52,14 +52,14 @@ const DesignStateHandler = ( {
 		return themeStatus.body.status;
 	};
 
-	const waitForInstall = () => {
-		setTimeout( async () => {
-			const themeStatus = await checkThemeStatus();
-			if ( themeStatus !== THEME_STATUS_ACTIVE ) {
-				return updateThemeStatus( THEME_STATUS_NOT_ACTIVE );
-			}
+	const expediteInstall = async () => {
+		const status = await expedite( DESIGN_STEPS_THEME );
+		if ( ! status.error ) {
 			window.location.reload();
-		}, THEME_INSTALL_WAIT_TIMEOUT );
+			return;
+		}
+
+		installThemeManually();
 	};
 
 	const enableNavigation = () => {
@@ -97,7 +97,7 @@ const DesignStateHandler = ( {
 		const themeStatus = await checkThemeStatus();
 		switch ( themeStatus ) {
 			case THEME_STATUS_INSTALLING:
-				waitForInstall();
+				expediteInstall();
 				break;
 			case THEME_STATUS_ACTIVE:
 				window.location.reload();

--- a/src/OnboardingSPA/utils/api/themes.js
+++ b/src/OnboardingSPA/utils/api/themes.js
@@ -37,6 +37,23 @@ const install = async ( theme, activate = true, queue = true ) => {
 	);
 };
 
+const expedite = async ( theme, activate = true ) => {
+	if ( typeof theme !== 'string' ) {
+		return false;
+	}
+
+	return await resolve(
+		apiFetch( {
+			url: installerRestURL( 'themes/expedite' ),
+			method: 'POST',
+			data: {
+				theme,
+				activate,
+			},
+		} )
+	);
+};
+
 const getGlobalStyles = async ( variations = false ) => {
 	return await resolve(
 		apiFetch( {
@@ -91,4 +108,5 @@ export {
 	getThemeColors,
 	getThemeFonts,
 	install,
+	expedite
 };

--- a/src/OnboardingSPA/utils/api/themes.js
+++ b/src/OnboardingSPA/utils/api/themes.js
@@ -108,5 +108,5 @@ export {
 	getThemeColors,
 	getThemeFonts,
 	install,
-	expedite
+	expedite,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -52,7 +52,6 @@ export const THEME_STATUS_NOT_ACTIVE = 'inactive';
 export const THEME_STATUS_INSTALLING = 'installing';
 export const THEME_STATUS_ACTIVE = 'activated';
 export const THEME_STATUS_FAILURE = 'failed';
-export const THEME_INSTALL_WAIT_TIMEOUT = 30000;
 
 export const CHAPTER_DEMOGRAPHIC = 'demographic';
 export const CHAPTER_COMMERCE = 'commerce';


### PR DESCRIPTION
It seems like WP_CRON is too slow on production sites and are causing the task to be stuck in the queue for a long time. This is causing the design steps to show the confirmation dialog. This PR expedites the installation task once a user reaches the design steps and the theme has not been installed yet.