### PR TITLE
Cypress Tests events API for get-experience page

### DIFF
--- a/tests/cypress/integration/2-general-onboarding-flow/get-started-experience.cy.js
+++ b/tests/cypress/integration/2-general-onboarding-flow/get-started-experience.cy.js
@@ -7,6 +7,7 @@ import {
 	CheckInfoPanel,
 	CheckIntroPanel,
 } from '../wp-module-support/sidebar.cy';
+import { APIList } from '../wp-module-support/EventsApi.cy';
 
 describe( 'Start Setup WP Experience Page', function () {
 	before( () => {
@@ -51,31 +52,21 @@ describe( 'Start Setup WP Experience Page', function () {
 		cy.url().should( 'contain', 'get-started/experience' );
 	} );
 
-	it( 'Checks if all the Radio Buttons are Enabled and Highlighted when clicked', () => {
-		let radioCount = 0;
-		const className = '.components-radio-control__option';
-		const arr = cy.get( className );
-		arr.each( () => {
-			cy.get( '[type="radio"]' )
-				.eq( radioCount )
-				.click( { force: true } )
-				.should( 'not.be.disabled' )
-				.should( 'be.checked' );
-			radioCount += 1;
-		} );
-	} );
-
 	const EventsAPI = ( experience_val ) => {
-		cy.intercept('http://localhost:8882/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=wp-setup&_locale=user').as('events');
-		cy.wait('@events').then((interception) => {
-			const responseBody = interception.request.body;
-			const responseData1 = responseBody[0].data;
-			const responseData2 = responseBody[1].data;
-			if("experience_level" in responseData1){
-				expect(responseData1.experience_level).equal(experience_val);
+		cy.intercept(APIList.get_started_experience).as('events');
+		cy.wait('@events').then((requestObject) => {
+			const responseBody = requestObject.request.body;
+			if(typeof responseBody[0].data != "undefined"){
+				const responseData1 = responseBody[0].data;
+				if("experience_level" in responseData1){
+					expect(responseData1.experience_level).equal(experience_val);
+				};
 			};
-			if("experience_level" in responseData2){
-				expect(responseData2.experience_level).equal(experience_val);
+			if(typeof responseBody[1].data != "undefined"){
+				const responseData2 = responseBody[1].data;
+				if("experience_level" in responseData2){
+					expect(responseData2.experience_level).equal(experience_val);
+				};
 			};
 		});
 	};
@@ -100,6 +91,20 @@ describe( 'Start Setup WP Experience Page', function () {
 					cy.wait(5000);
 					EventsAPI("expert");
 				};
+			radioCount += 1;
+		} );
+	} );
+
+	it( 'Checks if all the Radio Buttons are Enabled and Highlighted when clicked', () => {
+		let radioCount = 0;
+		const className = '.components-radio-control__option';
+		const arr = cy.get( className );
+		arr.each( () => {
+			cy.get( '[type="radio"]' )
+				.eq( radioCount )
+				.click( { force: true } )
+				.should( 'not.be.disabled' )
+				.should( 'be.checked' );
 			radioCount += 1;
 		} );
 	} );

--- a/tests/cypress/integration/2-general-onboarding-flow/get-started-experience.cy.js
+++ b/tests/cypress/integration/2-general-onboarding-flow/get-started-experience.cy.js
@@ -65,6 +65,45 @@ describe( 'Start Setup WP Experience Page', function () {
 		} );
 	} );
 
+	const EventsAPI = ( experience_val ) => {
+		cy.intercept('http://localhost:8882/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=wp-setup&_locale=user').as('events');
+		cy.wait('@events').then((interception) => {
+			const responseBody = interception.request.body;
+			const responseData1 = responseBody[0].data;
+			const responseData2 = responseBody[1].data;
+			if("experience_level" in responseData1){
+				expect(responseData1.experience_level).equal(experience_val);
+			};
+			if("experience_level" in responseData2){
+				expect(responseData2.experience_level).equal(experience_val);
+			};
+		});
+	};
+
+	it( 'Check if events API call being made after radio buttons are clicked', () => {
+		let radioCount = 0;
+		const className = '.components-radio-control__option';
+		const arr = cy.get( className );
+		arr.each( () => {
+			cy.reload();
+			cy.wait(2000);
+			cy.get( '[type="radio"]' )
+				.eq( radioCount )
+				.click( { force: true } )
+				if(radioCount==0){
+					EventsAPI("novice");
+				};
+				if(radioCount==1){
+					EventsAPI("intermediate");
+				};
+				if(radioCount>1){
+					cy.wait(5000);
+					EventsAPI("expert");
+				};
+			radioCount += 1;
+		} );
+	} );
+
 	it( 'Checks if Continue Setup Button is Enabled after the Radio Button is Checked.', () => {
 		cy.get( '[type=radio]:checked' ).should(
 			'have.css',

--- a/tests/cypress/integration/2-general-onboarding-flow/get-started-experience.cy.js
+++ b/tests/cypress/integration/2-general-onboarding-flow/get-started-experience.cy.js
@@ -35,9 +35,9 @@ describe( 'Start Setup WP Experience Page', function () {
 	} );
 
 	it( 'Check if `site` appears in heading', () => {
-		cy.get('.nfd-step-card-heading')
-			.should('be.visible')
-			.contains('site');
+		cy.get( '.nfd-step-card-heading' )
+			.should( 'be.visible' )
+			.contains( 'site' );
 	} );
 
 	it( 'Check if Radio Options load', () => {
@@ -53,20 +53,23 @@ describe( 'Start Setup WP Experience Page', function () {
 	} );
 
 	const EventsAPI = ( experience_val ) => {
-		cy.intercept(APIList.get_started_experience).as('events');
-		cy.wait('@events').then((requestObject) => {
+		cy.intercept( APIList.get_started_experience ).as( 'events' );
+		cy.wait( '@events' ).then( ( requestObject ) => {
 			const responseBody = requestObject.request.body;
-			const responseData1 = responseBody[0].data;
-			if("experience_level" in responseData1){
-				expect(responseData1.experience_level).equal(experience_val);
+			const responseData1 = responseBody[ 0 ].data;
+			if ( 'experience_level' in responseData1 ) {
+				expect( responseData1.experience_level ).equal(
+					experience_val
+				);
+			} else {
+				const responseData2 = responseBody[ 1 ].data;
+				if ( 'experience_level' in responseData2 ) {
+					expect( responseData2.experience_level ).equal(
+						experience_val
+					);
 				}
-			else{
-				const responseData2 = responseBody[1].data;
-				if("experience_level" in responseData2){
-					expect(responseData2.experience_level).equal(experience_val);
-				};
-			};
-		});
+			}
+		} );
 	};
 
 	it( 'Check if events API call being made after radio buttons are clicked', () => {
@@ -76,17 +79,17 @@ describe( 'Start Setup WP Experience Page', function () {
 		arr.each( () => {
 			cy.get( '[type="radio"]' )
 				.eq( radioCount )
-				.click( { force: true } )
-				if(radioCount==0){
-					EventsAPI("novice");
-				};
-				if(radioCount==1){
-					EventsAPI("intermediate");
-				};
-				if(radioCount>1){
-					cy.wait(5000);
-					EventsAPI("expert");
-				};
+				.click( { force: true } );
+			if ( radioCount == 0 ) {
+				EventsAPI( 'novice' );
+			}
+			if ( radioCount == 1 ) {
+				EventsAPI( 'intermediate' );
+			}
+			if ( radioCount > 1 ) {
+				cy.wait( 5000 );
+				EventsAPI( 'expert' );
+			}
 			radioCount += 1;
 		} );
 	} );

--- a/tests/cypress/integration/2-general-onboarding-flow/get-started-experience.cy.js
+++ b/tests/cypress/integration/2-general-onboarding-flow/get-started-experience.cy.js
@@ -56,13 +56,11 @@ describe( 'Start Setup WP Experience Page', function () {
 		cy.intercept(APIList.get_started_experience).as('events');
 		cy.wait('@events').then((requestObject) => {
 			const responseBody = requestObject.request.body;
-			if(typeof responseBody[0].data != "undefined"){
-				const responseData1 = responseBody[0].data;
-				if("experience_level" in responseData1){
-					expect(responseData1.experience_level).equal(experience_val);
-				};
-			};
-			if(typeof responseBody[1].data != "undefined"){
+			const responseData1 = responseBody[0].data;
+			if("experience_level" in responseData1){
+				expect(responseData1.experience_level).equal(experience_val);
+				}
+			else{
 				const responseData2 = responseBody[1].data;
 				if("experience_level" in responseData2){
 					expect(responseData2.experience_level).equal(experience_val);
@@ -76,8 +74,6 @@ describe( 'Start Setup WP Experience Page', function () {
 		const className = '.components-radio-control__option';
 		const arr = cy.get( className );
 		arr.each( () => {
-			cy.reload();
-			cy.wait(2000);
 			cy.get( '[type="radio"]' )
 				.eq( radioCount )
 				.click( { force: true } )

--- a/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-experience.cy.js
+++ b/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-experience.cy.js
@@ -35,9 +35,9 @@ describe( 'Start Setup WP Experience Page', function () {
 	} );
 
 	it( 'Check if `store` appears in heading', () => {
-		cy.get('.nfd-step-card-heading')
-			.should('be.visible')
-			.contains('store');
+		cy.get( '.nfd-step-card-heading' )
+			.should( 'be.visible' )
+			.contains( 'store' );
 	} );
 
 	it( 'Check if Radio Options load', () => {
@@ -53,20 +53,23 @@ describe( 'Start Setup WP Experience Page', function () {
 	} );
 
 	const EventsAPI = ( experience_val ) => {
-		cy.intercept(APIList.get_started_experience_ecomm).as('events');
-		cy.wait('@events').then((requestObject) => {
+		cy.intercept( APIList.get_started_experience_ecomm ).as( 'events' );
+		cy.wait( '@events' ).then( ( requestObject ) => {
 			const responseBody = requestObject.request.body;
-			const responseData1 = responseBody[0].data;
-			if("experience_level" in responseData1){
-				expect(responseData1.experience_level).equal(experience_val);
+			const responseData1 = responseBody[ 0 ].data;
+			if ( 'experience_level' in responseData1 ) {
+				expect( responseData1.experience_level ).equal(
+					experience_val
+				);
+			} else {
+				const responseData2 = responseBody[ 1 ].data;
+				if ( 'experience_level' in responseData2 ) {
+					expect( responseData2.experience_level ).equal(
+						experience_val
+					);
 				}
-			else{
-				const responseData2 = responseBody[1].data;
-				if("experience_level" in responseData2){
-					expect(responseData2.experience_level).equal(experience_val);
-				};
-			};
-		});
+			}
+		} );
 	};
 
 	it( 'Check if events API call being made after radio buttons are clicked', () => {
@@ -76,17 +79,17 @@ describe( 'Start Setup WP Experience Page', function () {
 		arr.each( () => {
 			cy.get( '[type="radio"]' )
 				.eq( radioCount )
-				.click( { force: true } )
-				if(radioCount==0){
-					EventsAPI("novice");
-				};
-				if(radioCount==1){
-					EventsAPI("intermediate");
-				};
-				if(radioCount>1){
-					cy.wait(5000);
-					EventsAPI("expert");
-				};
+				.click( { force: true } );
+			if ( radioCount == 0 ) {
+				EventsAPI( 'novice' );
+			}
+			if ( radioCount == 1 ) {
+				EventsAPI( 'intermediate' );
+			}
+			if ( radioCount > 1 ) {
+				cy.wait( 5000 );
+				EventsAPI( 'expert' );
+			}
 			radioCount += 1;
 		} );
 	} );

--- a/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-experience.cy.js
+++ b/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-experience.cy.js
@@ -7,6 +7,7 @@ import {
 	CheckInfoPanel,
 	CheckIntroPanel,
 } from '../wp-module-support/sidebar.cy';
+import { APIList } from '../wp-module-support/EventsApi.cy';
 
 describe( 'Start Setup WP Experience Page', function () {
 	before( () => {
@@ -51,31 +52,21 @@ describe( 'Start Setup WP Experience Page', function () {
 		cy.url().should( 'contain', 'get-started/experience' );
 	} );
 
-	it( 'Checks if all the Radio Buttons are Enabled and Highlighted when clicked', () => {
-		let radioCount = 0;
-		const className = '.components-radio-control__option';
-		const arr = cy.get( className );
-		arr.each( () => {
-			cy.get( '[type="radio"]' )
-				.eq( radioCount )
-				.click( { force: true } )
-				.should( 'not.be.disabled' )
-				.should( 'be.checked' );
-			radioCount += 1;
-		} );
-	} );
-
 	const EventsAPI = ( experience_val ) => {
-		cy.intercept('http://localhost:8882/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=ecommerce&_locale=user').as('events');
-		cy.wait('@events').then((interception) => {
-			const responseBody = interception.request.body;
-			const responseData1 = responseBody[0].data;
-			const responseData2 = responseBody[1].data;
-			if("experience_level" in responseData1){
-				expect(responseData1.experience_level).equal(experience_val);
+		cy.intercept(APIList.get_started_experience_ecomm).as('events');
+		cy.wait('@events').then((requestObject) => {
+			const responseBody = requestObject.request.body;
+			if(typeof responseBody[0].data != "undefined"){
+				const responseData1 = responseBody[0].data;
+				if("experience_level" in responseData1){
+					expect(responseData1.experience_level).equal(experience_val);
+				};
 			};
-			if("experience_level" in responseData2){
-				expect(responseData2.experience_level).equal(experience_val);
+			if(typeof responseBody[1].data != "undefined"){
+				const responseData2 = responseBody[1].data;
+				if("experience_level" in responseData2){
+					expect(responseData2.experience_level).equal(experience_val);
+				};
 			};
 		});
 	};
@@ -100,6 +91,20 @@ describe( 'Start Setup WP Experience Page', function () {
 					cy.wait(5000);
 					EventsAPI("expert");
 				};
+			radioCount += 1;
+		} );
+	} );
+
+	it( 'Checks if all the Radio Buttons are Enabled and Highlighted when clicked', () => {
+		let radioCount = 0;
+		const className = '.components-radio-control__option';
+		const arr = cy.get( className );
+		arr.each( () => {
+			cy.get( '[type="radio"]' )
+				.eq( radioCount )
+				.click( { force: true } )
+				.should( 'not.be.disabled' )
+				.should( 'be.checked' );
 			radioCount += 1;
 		} );
 	} );

--- a/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-experience.cy.js
+++ b/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-experience.cy.js
@@ -65,6 +65,45 @@ describe( 'Start Setup WP Experience Page', function () {
 		} );
 	} );
 
+	const EventsAPI = ( experience_val ) => {
+		cy.intercept('http://localhost:8882/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=ecommerce&_locale=user').as('events');
+		cy.wait('@events').then((interception) => {
+			const responseBody = interception.request.body;
+			const responseData1 = responseBody[0].data;
+			const responseData2 = responseBody[1].data;
+			if("experience_level" in responseData1){
+				expect(responseData1.experience_level).equal(experience_val);
+			};
+			if("experience_level" in responseData2){
+				expect(responseData2.experience_level).equal(experience_val);
+			};
+		});
+	};
+
+	it( 'Check if events API call being made after radio buttons are clicked', () => {
+		let radioCount = 0;
+		const className = '.components-radio-control__option';
+		const arr = cy.get( className );
+		arr.each( () => {
+			cy.reload();
+			cy.wait(2000);
+			cy.get( '[type="radio"]' )
+				.eq( radioCount )
+				.click( { force: true } )
+				if(radioCount==0){
+					EventsAPI("novice");
+				};
+				if(radioCount==1){
+					EventsAPI("intermediate");
+				};
+				if(radioCount>1){
+					cy.wait(5000);
+					EventsAPI("expert");
+				};
+			radioCount += 1;
+		} );
+	} );
+
 	it( 'Checks if Continue Setup Button is Enabled after the Radio Button is Checked.', () => {
 		cy.get( '[type=radio]:checked' ).should(
 			'have.css',

--- a/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-experience.cy.js
+++ b/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-experience.cy.js
@@ -56,13 +56,11 @@ describe( 'Start Setup WP Experience Page', function () {
 		cy.intercept(APIList.get_started_experience_ecomm).as('events');
 		cy.wait('@events').then((requestObject) => {
 			const responseBody = requestObject.request.body;
-			if(typeof responseBody[0].data != "undefined"){
-				const responseData1 = responseBody[0].data;
-				if("experience_level" in responseData1){
-					expect(responseData1.experience_level).equal(experience_val);
-				};
-			};
-			if(typeof responseBody[1].data != "undefined"){
+			const responseData1 = responseBody[0].data;
+			if("experience_level" in responseData1){
+				expect(responseData1.experience_level).equal(experience_val);
+				}
+			else{
 				const responseData2 = responseBody[1].data;
 				if("experience_level" in responseData2){
 					expect(responseData2.experience_level).equal(experience_val);
@@ -76,8 +74,6 @@ describe( 'Start Setup WP Experience Page', function () {
 		const className = '.components-radio-control__option';
 		const arr = cy.get( className );
 		arr.each( () => {
-			cy.reload();
-			cy.wait(2000);
 			cy.get( '[type="radio"]' )
 				.eq( radioCount )
 				.click( { force: true } )

--- a/tests/cypress/integration/wp-module-support/EventsApi.cy.js
+++ b/tests/cypress/integration/wp-module-support/EventsApi.cy.js
@@ -1,0 +1,4 @@
+export const APIList = {
+    'get_started_experience' : 'http://localhost:8882/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=wp-setup&_locale=user',
+    'get_started_experience_ecomm' : 'http://localhost:8882/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=ecommerce&_locale=user'
+}


### PR DESCRIPTION
Added Cypress Tests for events API on get-started-experience step for different API calls being made at the time of different options selected based on experience level.