### PR TITLE
Add Tests events API for top priority

### DIFF
--- a/tests/cypress/integration/2-general-onboarding-flow/get-started-experience.cy.js
+++ b/tests/cypress/integration/2-general-onboarding-flow/get-started-experience.cy.js
@@ -7,7 +7,7 @@ import {
 	CheckInfoPanel,
 	CheckIntroPanel,
 } from '../wp-module-support/sidebar.cy';
-import { APIList } from '../wp-module-support/EventsApi.cy';
+import { APIList, EventsAPI } from '../wp-module-support/EventsApi.cy';
 
 describe( 'Start Setup WP Experience Page', function () {
 	before( () => {
@@ -52,26 +52,6 @@ describe( 'Start Setup WP Experience Page', function () {
 		cy.url().should( 'contain', 'get-started/experience' );
 	} );
 
-	const EventsAPI = ( experience_val ) => {
-		cy.intercept( APIList.get_started_experience ).as( 'events' );
-		cy.wait( '@events' ).then( ( requestObject ) => {
-			const responseBody = requestObject.request.body;
-			const responseData1 = responseBody[ 0 ].data;
-			if ( 'experience_level' in responseData1 ) {
-				expect( responseData1.experience_level ).equal(
-					experience_val
-				);
-			} else {
-				const responseData2 = responseBody[ 1 ].data;
-				if ( 'experience_level' in responseData2 ) {
-					expect( responseData2.experience_level ).equal(
-						experience_val
-					);
-				}
-			}
-		} );
-	};
-
 	it( 'Check if events API call being made after radio buttons are clicked', () => {
 		let radioCount = 0;
 		const className = '.components-radio-control__option';
@@ -81,14 +61,14 @@ describe( 'Start Setup WP Experience Page', function () {
 				.eq( radioCount )
 				.click( { force: true } );
 			if ( radioCount == 0 ) {
-				EventsAPI( 'novice' );
+				EventsAPI( 'experience_level', 'novice', APIList.get_started_experience );
 			}
 			if ( radioCount == 1 ) {
-				EventsAPI( 'intermediate' );
+				EventsAPI( 'experience_level', 'intermediate', APIList.get_started_experience );
 			}
 			if ( radioCount > 1 ) {
 				cy.wait( 5000 );
-				EventsAPI( 'expert' );
+				EventsAPI( 'experience_level', 'expert', APIList.get_started_experience );
 			}
 			radioCount += 1;
 		} );

--- a/tests/cypress/integration/2-general-onboarding-flow/top-priority.cy.js
+++ b/tests/cypress/integration/2-general-onboarding-flow/top-priority.cy.js
@@ -1,6 +1,7 @@
 // <reference types="Cypress" />
 import { DrawerActivityForMenu } from '../wp-module-support/drawer.cy';
 import { CheckHeadingSubheading } from '../wp-module-support/header.cy';
+import { EventsAPI, APIList } from '../wp-module-support/EventsApi.cy';
 
 describe( 'Top Priority Page', function () {
 	before( () => {
@@ -25,6 +26,29 @@ describe( 'Top Priority Page', function () {
 
 	it( 'Check existence of Skip this Step button', () => {
 		cy.get( '.components-button.skip-button' ).should( 'be.visible' );
+	} );
+
+	it( 'Check for API events when different cards are selected', ()=> {
+		let previewCount = 0;
+		const className = '.components-surface.components-card.nfd-card';
+		const arr = cy.get( className );
+		arr.each( () => {
+			cy.get( className )
+				.eq( previewCount )
+				.should( 'be.visible' )
+				.click();
+				if ( previewCount == 0 ) {
+					EventsAPI( 'top_priority', 'content', APIList.top_priority );
+				}
+				if ( previewCount == 1 ) {
+					EventsAPI( 'top_priority', 'store', APIList.top_priority );
+				}
+				if ( previewCount > 1 ) {
+					cy.wait( 5000 );
+					EventsAPI( 'top_priority', 'design', APIList.top_priority );
+				}
+		previewCount += 1;
+		});
 	} );
 
 	it.skip( 'Click on different cards and move on to next page', () => {

--- a/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-experience.cy.js
+++ b/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-experience.cy.js
@@ -7,7 +7,7 @@ import {
 	CheckInfoPanel,
 	CheckIntroPanel,
 } from '../wp-module-support/sidebar.cy';
-import { APIList } from '../wp-module-support/EventsApi.cy';
+import { APIList, EventsAPI } from '../wp-module-support/EventsApi.cy';
 
 describe( 'Start Setup WP Experience Page', function () {
 	before( () => {
@@ -52,26 +52,6 @@ describe( 'Start Setup WP Experience Page', function () {
 		cy.url().should( 'contain', 'get-started/experience' );
 	} );
 
-	const EventsAPI = ( experience_val ) => {
-		cy.intercept( APIList.get_started_experience_ecomm ).as( 'events' );
-		cy.wait( '@events' ).then( ( requestObject ) => {
-			const responseBody = requestObject.request.body;
-			const responseData1 = responseBody[ 0 ].data;
-			if ( 'experience_level' in responseData1 ) {
-				expect( responseData1.experience_level ).equal(
-					experience_val
-				);
-			} else {
-				const responseData2 = responseBody[ 1 ].data;
-				if ( 'experience_level' in responseData2 ) {
-					expect( responseData2.experience_level ).equal(
-						experience_val
-					);
-				}
-			}
-		} );
-	};
-
 	it( 'Check if events API call being made after radio buttons are clicked', () => {
 		let radioCount = 0;
 		const className = '.components-radio-control__option';
@@ -81,14 +61,14 @@ describe( 'Start Setup WP Experience Page', function () {
 				.eq( radioCount )
 				.click( { force: true } );
 			if ( radioCount == 0 ) {
-				EventsAPI( 'novice' );
+				EventsAPI( 'experience_level', 'novice', APIList.get_started_experience_ecomm );
 			}
 			if ( radioCount == 1 ) {
-				EventsAPI( 'intermediate' );
+				EventsAPI( 'experience_level', 'intermediate', APIList.get_started_experience_ecomm );
 			}
 			if ( radioCount > 1 ) {
 				cy.wait( 5000 );
-				EventsAPI( 'expert' );
+				EventsAPI( 'experience_level', 'expert', APIList.get_started_experience_ecomm );
 			}
 			radioCount += 1;
 		} );

--- a/tests/cypress/integration/wp-module-support/EventsApi.cy.js
+++ b/tests/cypress/integration/wp-module-support/EventsApi.cy.js
@@ -1,4 +1,41 @@
 export const APIList = {
     'get_started_experience' : 'http://localhost:8882/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=wp-setup&_locale=user',
-    'get_started_experience_ecomm' : 'http://localhost:8882/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=ecommerce&_locale=user'
+    'get_started_experience_ecomm' : 'http://localhost:8882/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=ecommerce&_locale=user',
+    'top_priority' : 'http://localhost:8882/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=wp-setup&_locale=user'
 }
+
+export const EventsAPI = ( events_name, card_val, api_name ) => {
+    cy.intercept( api_name ).as( 'events' );
+    cy.wait( '@events' ).then( ( requestObject ) => {
+    const responseBody = requestObject.request.body;
+    const responseData1 = responseBody[ 0 ].data;
+    if(events_name == 'experience_level'){
+        if ( events_name in responseData1 ) {
+            expect( responseData1.experience_level ).equal(
+                card_val
+            );
+        } else {
+            const responseData2 = responseBody[ 1 ].data;
+            if ( events_name in responseData2 ) {
+                expect( responseData2.experience_level ).equal(
+                    card_val
+                );
+            }
+        }
+    };
+    if(events_name == 'top_priority'){
+        if ( events_name in responseData1 ) {
+            expect( responseData1.top_priority ).equal(
+                card_val
+            );
+        } else {
+            const responseData2 = responseBody[ 1 ].data;
+            if ( events_name in responseData2 ) {
+                expect( responseData2.top_priority ).equal(
+                    card_val
+                );
+            }
+        }
+    };
+    });
+};


### PR DESCRIPTION
Adding cypress tests for events API for the top priority page also some code enhancements by calling a single function inside the EventsAPI file as it is similar for get_started_experience pages as well.