### PR TITLE
Update logic for onboarding redirects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
 		"mustache/mustache": "^2.14",
 		"wp-cli/wp-config-transformer": "^1.3",
 		"newfold-labs/wp-module-onboarding-data": "^0.0.7",
-		"newfold-labs/wp-module-patterns": "^0.1.8"
+		"newfold-labs/wp-module-patterns": "^0.1.8",
+		"newfold-labs/wp-module-install-checker": "^1.0"
 	},
 	"require-dev": {
 		"wp-phpunit/wp-phpunit": "^6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8faf86a6d756141200de800ab7eca372",
+    "content-hash": "c3ac49045042d9c8b527f0d45f30ed64",
     "packages": [
         {
             "name": "mustache/mustache",
@@ -104,6 +104,45 @@
                 "issues": "https://github.com/newfold-labs/wp-module-data/issues"
             },
             "time": "2023-11-13T19:54:44+00:00"
+        },
+        {
+            "name": "newfold-labs/wp-module-install-checker",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/newfold-labs/wp-module-install-checker.git",
+                "reference": "586485f02a31f598f1d00a7d81acbb58a556cce4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-install-checker/zipball/586485f02a31f598f1d00a7d81acbb58a556cce4",
+                "reference": "586485f02a31f598f1d00a7d81acbb58a556cce4",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "NewfoldLabs\\WP\\Module\\InstallChecker\\": "src/"
+                }
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Micah Wood",
+                    "homepage": "https://wpscholar.com"
+                }
+            ],
+            "description": "A module that handles checking a WordPress installation to see if it is a fresh install and to fetch the estimated installation date.",
+            "support": {
+                "source": "https://github.com/newfold-labs/wp-module-install-checker/tree/1.0.0",
+                "issues": "https://github.com/newfold-labs/wp-module-install-checker/issues"
+            },
+            "time": "2023-11-28T01:36:11+00:00"
         },
         {
             "name": "newfold-labs/wp-module-installer",


### PR DESCRIPTION
This PR utilizes the new Install Checker module to check if a site is a fresh WordPress install and updates the logic for redirects as follows: 

- Always skip onboarding if user isn't an admin
- Allow manually disabling onboarding (via query param - sets DB option)
- Allow manually enabling onboarding (via query param - sets DB option)
- Check if onboarding is explicitly on or off (via DB option)
- If explicitly on, go ahead and trigger onboarding
- If explicitly off, bypass onboarding
- If not explicitly set, run through qualifiers
  - User hasn't completed or exited onboarding already
  - Site is fresh install (use module for this)
  - Coming soon is not enabled
- If onboarding redirect is triggered at any point, update the DB option to disable onboarding for future visits