### PR TITLE
Improve fork logic to switch based on the brand config.

### DIFF
--- a/src/OnboardingSPA/steps/TheFork/index.js
+++ b/src/OnboardingSPA/steps/TheFork/index.js
@@ -9,7 +9,7 @@ import { HEADER_SITEGEN } from '../../../constants';
 import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@wordpress/components';
-import { SITEGEN_FLOW } from '../../data/flows/constants';
+import { DEFAULT_FLOW, SITEGEN_FLOW } from '../../data/flows/constants';
 
 import { resolveGetDataForFlow } from '../../data/flows';
 import { validateFlow } from '../../data/flows/utils';
@@ -65,7 +65,7 @@ const TheFork = () => {
 
 	const oldFlow = window.nfdOnboarding?.oldFlow
 		? window.nfdOnboarding.oldFlow
-		: window.nfdOnboarding.currentFlow;
+		: DEFAULT_FLOW;
 	return (
 		<CommonLayout
 			isCentered
@@ -75,12 +75,14 @@ const TheFork = () => {
 				The Fork
 			</h1>
 			<div className="nfd-onboarding-step--site-gen__fork__buttons">
-				<Button
-					className="nfd-onboarding-step--site-gen__fork__buttons__button"
-					onClick={ () => switchFlow( SITEGEN_FLOW ) }
-				>
-					Goto sitegen flow
-				</Button>
+				{ validateFlow( brandConfig, SITEGEN_FLOW ) && (
+					<Button
+						className="nfd-onboarding-step--site-gen__fork__buttons__button"
+						onClick={ () => switchFlow( SITEGEN_FLOW ) }
+					>
+						Goto sitegen flow
+					</Button>
+				) }
 				<Button
 					className="nfd-onboarding-step--site-gen__fork__buttons__button"
 					onClick={ () => switchFlow( oldFlow ) }


### PR DESCRIPTION
I noticed this issue during testing of the recent AI Onboarding changes. Users were unable to switch to the normal flow once they had visited `sitegen` at least once. I am attaching before and after videos for reference.

Before:

https://github.com/newfold-labs/wp-module-onboarding/assets/38878906/bb914cdd-2e39-43db-9e09-d2f2c12fea28

After:

https://github.com/newfold-labs/wp-module-onboarding/assets/38878906/c9171dec-2e27-4845-a0ed-6819e4a73c42

Additionally, the AI Website Creator button is now hidden when the flow has not been enabled for a specific brand.

**Note:** This update addresses only the step calculation logic; the UI is still under development.

