### PR TITLE
Fix fonts for orchid shades and correct typography step issues

### DIFF
--- a/src/OnboardingSPA/components/App/index.js
+++ b/src/OnboardingSPA/components/App/index.js
@@ -158,7 +158,7 @@ const App = () => {
 	function handleConditionalDesignStepsRoutes() {
 		if (
 			location?.pathname.includes( 'colors' ) ||
-			location?.pathname.includes( 'fonts' )
+			location?.pathname.includes( 'typography' )
 		) {
 			const updates = injectInAllSteps(
 				allSteps,

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignFonts.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignFonts.js
@@ -85,17 +85,17 @@ const DesignFonts = () => {
 
 		if (
 			globalStylesCopy?.styles?.typography?.fontFamily &&
-			globalStylesCopy?.styles?.blocks[ 'core/heading' ]?.typography
-				?.fontFamily
+			globalStylesCopy?.styles?.blocks[ 'core/heading' ]
 		) {
 			globalStylesCopy.styles.typography.fontFamily =
 				fontPalettesCopy[ fontStyle ]?.styles?.typography?.fontFamily;
-			globalStylesCopy.styles.blocks[
-				'core/heading'
-			].typography.fontFamily =
-				fontPalettesCopy[ fontStyle ]?.styles.blocks[
-					'core/heading'
-				].typography.fontFamily;
+			globalStylesCopy.styles.blocks[ 'core/heading' ] = {
+				...globalStylesCopy.styles.blocks[ 'core/heading' ],
+				typography:
+					fontPalettesCopy[ fontStyle ]?.styles.blocks[
+						'core/heading'
+					].typography,
+			};
 		}
 
 		if (


### PR DESCRIPTION
1. Fixes issue with fonts not applying to the orchid shades preview.
2. Fixes the typography step that incorrectly displays the Finish button on a page refresh.