### PR TITLE
Fix issue with fonts in SiteGen customize sidebar

### DIFF
--- a/src/OnboardingSPA/components/Sidebar/components/Customize/DesignFontsPanel/index.js
+++ b/src/OnboardingSPA/components/Sidebar/components/Customize/DesignFontsPanel/index.js
@@ -293,8 +293,8 @@ const DesignFontsPanel = forwardRef(
 					customFont;
 				}
 			} else {
-				headings = `var(--wp--preset--font-family--${ fontGroups[ selectedGroup ].headings })`;
-				body = `var(--wp--preset--font-family--${ fontGroups[ selectedGroup ].body })`;
+				headings = `var(--wp--preset--font-family--${ fontGroups[ selectedGroup ].headingsSlug })`;
+				body = `var(--wp--preset--font-family--${ fontGroups[ selectedGroup ].bodySlug })`;
 			}
 			setStylesOfCurrentData( headings, body );
 		};


### PR DESCRIPTION
In SiteGen customize sidebar, when fonts are getting selected, names have been applied instead of slugs. It is updated to use font slug.