### PR TITLE
Fix default palette issue in SiteGen Customize Sidebar

### DIFF
--- a/src/OnboardingSPA/components/Sidebar/components/Customize/DesignColorsPanel/index.js
+++ b/src/OnboardingSPA/components/Sidebar/components/Customize/DesignColorsPanel/index.js
@@ -30,14 +30,19 @@ const DesignColorsPanel = forwardRef(
 			resetToDefaultColors,
 		} ) );
 
-		const { currentData, customizeSidebarData } = useSelect( ( select ) => {
-			return {
-				currentData:
-					select( nfdOnboardingStore ).getCurrentOnboardingData(),
-				customizeSidebarData:
-					select( nfdOnboardingStore ).getCustomizeSidebarData(),
-			};
-		} );
+		const { currentData, customizeSidebarData, themeColors } = useSelect(
+			( select ) => {
+				return {
+					currentData:
+						select( nfdOnboardingStore ).getCurrentOnboardingData(),
+					customizeSidebarData:
+						select( nfdOnboardingStore ).getCustomizeSidebarData(),
+					themeColors:
+						select( nfdOnboardingStore ).getPreviewSettings()
+							.settings.colors,
+				};
+			}
+		);
 
 		useEffect( () => {
 			const slug = currentData.sitegen?.homepages?.active?.slug;
@@ -60,13 +65,19 @@ const DesignColorsPanel = forwardRef(
 		}, [ currentData ] );
 
 		const colorPalettes = customizeSidebarData?.colorPalettes;
+		let palettePrimaryColors = themeColors?.map( ( colorObj ) => ( {
+			name: colorObj.name,
+			color: colorObj.color,
+		} ) );
 
-		const palettePrimaryColors = Object.entries( colorPalettes[ 0 ] ).map(
-			( [ , color ] ) => ( {
-				name: __( 'Custom', 'wp-module-onboarding' ),
-				color,
-			} )
-		);
+		if ( ! palettePrimaryColors ) {
+			palettePrimaryColors = Object.entries( colorPalettes[ 0 ] ).map(
+				( [ , color ] ) => ( {
+					name: __( 'Custom', 'wp-module-onboarding' ),
+					color,
+				} )
+			);
+		}
 
 		const definePalettes = () => {
 			const palettes = [];

--- a/src/OnboardingSPA/components/Sidebar/components/Customize/DesignColorsPanel/index.js
+++ b/src/OnboardingSPA/components/Sidebar/components/Customize/DesignColorsPanel/index.js
@@ -124,7 +124,7 @@ const DesignColorsPanel = forwardRef(
 			}
 
 			if ( ! selectedPalette && selectedPalette !== 0 ) {
-				const selectedPaletteToSet = activeColor.selectedPalette;
+				const selectedPaletteToSet = activeColor.selectedPalette || 0;
 				setSelectedPalette( selectedPaletteToSet );
 				if ( selectedPaletteToSet === 'custom' ) {
 					setShowCustomColors( true );

--- a/src/OnboardingSPA/components/Sidebar/components/Customize/DesignColorsPanel/stylesheet.scss
+++ b/src/OnboardingSPA/components/Sidebar/components/Customize/DesignColorsPanel/stylesheet.scss
@@ -20,7 +20,7 @@
 				display: flex;
 				gap: 20px;
 				padding: 10px 4px;
-				overflow-x: auto;
+				flex-wrap: wrap;
 				max-width: 250px;
 			}
 


### PR DESCRIPTION
This pull request addresses the issue of the default color palette not being prioritized as the first option in the sitegen customize sidebar. The current implementation may cause confusion for users who expect the default colors to be easily accessible when customizing their site.