### PR TITLE
Remove overlapping of Exit to WordPress button on smaller screens

### DIFF
--- a/src/OnboardingSPA/components/Header/stylesheet.scss
+++ b/src/OnboardingSPA/components/Header/stylesheet.scss
@@ -25,10 +25,6 @@ $nfd-onboarding-editor-header-hover: #272d30;
 		transition-delay: 80ms;
 
 		@include reduce-motion("transition");
-
-		@media (max-width: #{ ($break-xlarge) }) {
-			padding-left: 4px;
-		}
 	}
 
 	&__start,


### PR DESCRIPTION
<img width="855" alt="Screenshot 2024-02-27 at 3 52 14 PM" src="https://github.com/newfold-labs/wp-module-onboarding/assets/48691514/4727e94a-2a71-4ee2-936f-ef028a2a60b1">
