### PR TITLE
Added fix for deprecated warning from onboarding module.

### DIFF
--- a/includes/WP_Admin.php
+++ b/includes/WP_Admin.php
@@ -60,7 +60,7 @@ final class WP_Admin {
 	 */
 	public static function register_page() {
 		\add_submenu_page(
-			null,
+			'',
 			\__( 'Onboarding', 'wp-module-onboarding' ),
 			\__( 'Onboarding', 'wp-module-onboarding' ),
 			Permissions::ADMIN,


### PR DESCRIPTION
Cannot pass null parameters to the add_submenu_page function. Updated the parameters to an empty string.