### PR TITLE
Move `configure_activation_transient` to page loads only

### DIFF
--- a/includes/Application.php
+++ b/includes/Application.php
@@ -76,10 +76,8 @@ final class Application {
 
 		if ( Permissions::is_authorized_admin() ) {
 			StatusService::track();
+			PluginService::configure_activation_transient();
 		}
-
-		// Adds a transient to activate plugins in all scenarios.
-		PluginService::configure_activation_transient();
 
 		\do_action( 'nfd_module_onboarding_post_init' );
 	}


### PR DESCRIPTION
## Proposed changes

This resolves the race condition between `initialize` and `configure_activation_transient`.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
