### PR TITLE
Fix issue with custom fonts preview

### DIFF
--- a/src/OnboardingSPA/components/Sidebar/components/Customize/DesignFontsPanel/index.js
+++ b/src/OnboardingSPA/components/Sidebar/components/Customize/DesignFontsPanel/index.js
@@ -356,6 +356,7 @@ const DesignFontsPanel = forwardRef(
 
 		const handleSelectYourOwnFonts = () => {
 			setShowCustomFonts( true );
+			setSelectedGroup( 'custom' );
 			if ( ! selectedCustomFont ) {
 				setIsEditingCustomFont( true );
 			}
@@ -366,7 +367,7 @@ const DesignFontsPanel = forwardRef(
 		};
 
 		const handleCancelCustomFonts = () => {
-			if ( ! selectedCustomFont ) {
+			if ( ! selectedCustomFont.heading || ! selectedCustomFont.body ) {
 				setShowCustomFonts( false );
 			} else {
 				setIsEditingCustomFont( false );


### PR DESCRIPTION
## Proposed changes

In SiteGen customisation step, the custom fonts are not getting reflected in the preview. This PR will ensure that the fonts selected are always reflected in the preview.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

