### PR TITLE
Remove `flow` param for Events API requests

### DIFF
--- a/.github/workflows/lint-check-php.yml
+++ b/.github/workflows/lint-check-php.yml
@@ -8,6 +8,7 @@ on:
     types: [opened, edited, reopened, ready_for_review]
     paths:
       - '**.php'
+      - '!build/**/*.php'
   workflow_dispatch:
 
 concurrency:

--- a/src/OnboardingSPA/utils/api/common.js
+++ b/src/OnboardingSPA/utils/api/common.js
@@ -5,10 +5,10 @@ import {
 	migrateRestBase,
 } from '../../../constants';
 
-export const onboardingRestURL = ( api ) => {
+export const onboardingRestURL = ( api, includeFlow = true ) => {
 	return (
 		`${ onboardingRestBase }/${ api }` +
-		( window.nfdOnboarding?.currentFlow
+		( includeFlow && window.nfdOnboarding?.currentFlow
 			? `&flow=${ window.nfdOnboarding.currentFlow }`
 			: '' )
 	);

--- a/src/onboarding.js
+++ b/src/onboarding.js
@@ -14,8 +14,8 @@ if ( runtimeDataExists ) {
 		HiiveAnalytics.initialize( {
 			namespace: CATEGORY,
 			urls: {
-				single: onboardingRestURL( 'events' ),
-				batch: onboardingRestURL( 'events/batch' ),
+				single: onboardingRestURL( 'events', false ),
+				batch: onboardingRestURL( 'events/batch', false ),
 			},
 			settings: {
 				debounce: {

--- a/tests/cypress/integration/wp-module-support/EventsApi.cy.js
+++ b/tests/cypress/integration/wp-module-support/EventsApi.cy.js
@@ -1,6 +1,6 @@
 export const APIList = {
-	events_api_general_onb: '/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=wp-setup&_locale=user',
-	events_api_ecomm: '/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&flow=ecommerce&_locale=user'
+	events_api_general_onb: '/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&_locale=user',
+	events_api_ecomm: '/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents%2Fbatch&_locale=user'
 };
 
 export const EventsAPI = ( events_name, card_val, api_name ) => {


### PR DESCRIPTION
## Proposed changes

For the events API, since we are initializing the namespace at the beginning of onboarding, we will not be able to keep up with the change in the flow parameter, which is part of the URL. This parameter is not being used at all in the events API and is also unnecessary.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
