### PR TITLE
Fix header Menu in DIY flow when Primary and Secondary Type are not selected

### DIFF
--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignHeaderMenu.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignHeaderMenu.js
@@ -131,7 +131,7 @@ const DesignHeaderMenu = () => {
 
 		updateSelectedPattern( chosenPattern );
 		trackOnboardingEvent(
-			new OnboardingEvent( ACTION_HEADER_SELECTED, chosenPattern )
+			new OnboardingEvent( ACTION_HEADER_SELECTED, chosenPattern.slug )
 		);
 	};
 

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignHeaderMenu.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignHeaderMenu.js
@@ -61,8 +61,9 @@ const DesignHeaderMenu = () => {
 		}
 
 		if (
-			! currentData.data?.partFooter ||
-			currentData.data?.partFooter === ''
+			( ! currentData.data?.partFooter ||
+				currentData.data?.partFooter === '' ) &&
+			footerPattern?.length > 0
 		) {
 			currentData.data.partFooter = footerPattern.slug;
 			setCurrentOnboardingData( currentData );

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignHeaderMenu.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignHeaderMenu.js
@@ -89,6 +89,36 @@ const DesignHeaderMenu = () => {
 		}
 	}, [ themeStatus ] );
 
+	useEffect( () => {
+		/* choose the first pattern if the fallback pattern is replaced with priamry/secondary type */
+		if (
+			patterns?.length > 0 &&
+			! patterns.some( ( pattern ) => pattern.slug === selectedPattern )
+		) {
+			const firstPattern = patterns[ 0 ];
+			updateSelectedPattern( firstPattern );
+		}
+	}, [ patterns, selectedPattern ] );
+
+	const updateSelectedPattern = ( pattern ) => {
+		setSelectedPattern( pattern.slug );
+		currentData.data.partHeader = pattern.slug;
+		setCurrentOnboardingData( currentData );
+
+		const newPagePattern = pattern.content + headerMenuPreviewData.pageBody;
+		setHeaderMenuData( newPagePattern );
+
+		setFlow( currentData ).then( ( result ) => {
+			if ( ! result?.error ) {
+				setCurrentOnboardingData( currentData );
+			}
+		} );
+
+		trackOnboardingEvent(
+			new OnboardingEvent( ACTION_HEADER_SELECTED, pattern )
+		);
+	};
+
 	const handleClick = async ( idx ) => {
 		if ( document.getElementsByClassName( 'nfd-onboard-content' ) ) {
 			document
@@ -104,22 +134,7 @@ const DesignHeaderMenu = () => {
 			return true;
 		}
 
-		setSelectedPattern( chosenPattern.slug );
-		currentData.data.partHeader = chosenPattern.slug;
-		setCurrentOnboardingData( currentData );
-
-		const newPagePattern =
-			chosenPattern.content + headerMenuPreviewData.pageBody;
-		setHeaderMenuData( newPagePattern );
-
-		// API call to make sure the DB is in sync with the store for the selected header menu
-		const result = await setFlow( currentData );
-		if ( result?.error === null ) {
-			setCurrentOnboardingData( currentData );
-		}
-		trackOnboardingEvent(
-			new OnboardingEvent( ACTION_HEADER_SELECTED, chosenPattern.slug )
-		);
+		updateSelectedPattern( chosenPattern );
 	};
 
 	const buildPreviews = () => {

--- a/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignHeaderMenu.js
+++ b/src/OnboardingSPA/components/Drawer/DrawerPanel/DesignHeaderMenu.js
@@ -95,8 +95,7 @@ const DesignHeaderMenu = () => {
 			patterns?.length > 0 &&
 			! patterns.some( ( pattern ) => pattern.slug === selectedPattern )
 		) {
-			const firstPattern = patterns[ 0 ];
-			updateSelectedPattern( firstPattern );
+			updateSelectedPattern( patterns[ 0 ] );
 		}
 	}, [ patterns, selectedPattern ] );
 
@@ -113,10 +112,6 @@ const DesignHeaderMenu = () => {
 				setCurrentOnboardingData( currentData );
 			}
 		} );
-
-		trackOnboardingEvent(
-			new OnboardingEvent( ACTION_HEADER_SELECTED, pattern )
-		);
 	};
 
 	const handleClick = async ( idx ) => {
@@ -135,6 +130,9 @@ const DesignHeaderMenu = () => {
 		}
 
 		updateSelectedPattern( chosenPattern );
+		trackOnboardingEvent(
+			new OnboardingEvent( ACTION_HEADER_SELECTED, chosenPattern )
+		);
 	};
 
 	const buildPreviews = () => {


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

PRESS0-1871:
https://jira.newfold.com/browse/PRESS0-1871

When the Primary Type and Secondary Type are not selected by the user, the header menu is rendered from the fallback theme and not fetched from the wonder-blocks. Since the fallback array did not have the header and footer the header-menu step in the DIY flow was breaking. Added the header and footer as a fallback in the onboarding-data module https://github.com/newfold-labs/wp-module-onboarding-data/pull/110
Also added a footer length check to ensure that the layout doesn't break. 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
