### PR TITLE
Fix Failing Onboarding Test

### DIFF
--- a/src/OnboardingSPA/index.js
+++ b/src/OnboardingSPA/index.js
@@ -50,6 +50,7 @@ export async function initializeNFDOnboarding( id, runtime ) {
 	}
 
 	const currentData = await getFlow();
+	
 	if ( currentData.error === null ) {
 		currentData.body = initializeFlowData( currentData.body );
 		dispatch( nfdOnboardingStore ).setCurrentOnboardingData(

--- a/tests/cypress/integration/2-general-onboarding-flow/get-started-welcome.cy.js
+++ b/tests/cypress/integration/2-general-onboarding-flow/get-started-welcome.cy.js
@@ -84,9 +84,6 @@ describe( 'Get Started Welcome Page', function () {
 		GetPluginName();
 	} );
 
-	it( 'Check navigation back button is not visible', () => {
-		cy.get( '.navigation-buttons_back' ).should('exist');
-	} );
 
 	it( 'Check if next step loads on clicking navigation next', () => {
 		cy.get( '.navigation-buttons_next' ).click();

--- a/tests/cypress/integration/2-general-onboarding-flow/get-started-welcome.cy.js
+++ b/tests/cypress/integration/2-general-onboarding-flow/get-started-welcome.cy.js
@@ -84,8 +84,8 @@ describe( 'Get Started Welcome Page', function () {
 		GetPluginName();
 	} );
 
-	it( 'Check navigation back is not visible', () => {
-		cy.get( '.navigation-buttons_back' ).should('not.exist');
+	it( 'Check navigation back button is not visible', () => {
+		cy.get( '.navigation-buttons_back' ).should('exist');
 	} );
 
 	it( 'Check if next step loads on clicking navigation next', () => {

--- a/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-welcome.cy.js
+++ b/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-welcome.cy.js
@@ -83,8 +83,8 @@ describe( 'Get Started Welcome Page', function () {
 		GetPluginName();
 	} );
 
-	it( 'Check navigation back is not visible', () => {
-		cy.get( '.navigation-buttons_back' ).should( 'not.exist' );
+	it( 'Check navigation back button is not visible', () => {
+		cy.get( '.navigation-buttons_back' ).should('exist');
 	} );
 
 	it( 'Check if next step loads on clicking navigation next', () => {

--- a/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-welcome.cy.js
+++ b/tests/cypress/integration/3-ecommerce-onboarding-flow/get-started-welcome.cy.js
@@ -83,10 +83,6 @@ describe( 'Get Started Welcome Page', function () {
 		GetPluginName();
 	} );
 
-	it( 'Check navigation back button is not visible', () => {
-		cy.get( '.navigation-buttons_back' ).should('exist');
-	} );
-
 	it( 'Check if next step loads on clicking navigation next', () => {
 		cy.get( '.navigation-buttons_next' ).click();
 		cy.url().should( 'not.include', '#/wp-setup/step/get-started/welcome' );


### PR DESCRIPTION
## Proposed changes

Investigate and fix failing test cases.
The navigation back button should not exist when the Capability hasAISitegen is false however now we set hasAISitegen by default for users in [Link](https://github.com/newfold-labs/wp-module-data/blob/91d1b03162f23b7b8bd3a41d9496eb8017df0051/bootstrap.php#L79-L92) and fork is always enabled even in the cypress env due to which the Back button exists.

Solution:

1. Update Cypress to reverse the check, and when the hardcoded hasAISitegen is removed again, change it to the current state.As the hardcoded changes only exist in the Bluehost plugin, opting for this solution might also require brand-specific checks
2. Remove this check itself as AI Sitegen happens for 100% of customers and there is no case where there will be no fork page.



Going with approach 2 and removing this as doing all those checks is an overkill.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
