### PR TITLE
PRESS0-1954 - Verify Migration Event Reporting on Fork Step shows once

### DIFF
--- a/tests/cypress/integration/5-AI-SiteGen-onboarding-flow/fork-migration-event.cy.js
+++ b/tests/cypress/integration/5-AI-SiteGen-onboarding-flow/fork-migration-event.cy.js
@@ -1,0 +1,55 @@
+import {
+	AdminBarCheck,
+	DarkBGCheck,
+	LightBGCheck,
+} from '../wp-module-support/siteGen.cy';
+import { apiList, migrationConnection } from '../wp-module-support/MockApi.cy';
+import { flow } from 'lodash';
+
+const waitTime = 60000;
+const customCommandTimeout = 20000;
+
+describe( 'SiteGen Fork Step', function () {
+	before( () => {
+		cy.wait( 10000 );
+		cy.visit( 'wp-admin/?page=nfd-onboarding#/wp-setup/step/fork' );
+	} );
+
+	it( 'Verify Migration Event Reporting on Fork Step shows once', () => {
+		cy.get( 'div[data-flow="migration"]', {
+			timeout: customCommandTimeout,
+		} )
+			.scrollIntoView()
+			.should( 'exist' );
+		let migrateEventsCounts = 0;
+		cy.intercept(
+			'POST',
+			'**/index.php?rest_route=%2Fnewfold-onboarding%2Fv1%2Fevents*'
+		).as( 'fork-migrate-event' );
+		cy.get( 'div[data-flow="migration"]', {
+			timeout: customCommandTimeout,
+		} )
+			.scrollIntoView()
+			.click();
+
+		cy.get( '.white-label-migration', { timeout: customCommandTimeout } )
+			.scrollIntoView()
+			.should( 'exist' );
+		cy.wait( '@fork-migrate-event', { timeout: customCommandTimeout } )
+			.then( ( interception ) => {
+				expect( interception.response.statusCode ).to.eq( 202 );
+				const payload = interception.request.body;
+				payload.forEach( ( body ) => {
+					if (
+						body.data.hasOwnProperty( 'flow' ) &&
+						body.data.flow == 'MIGRATE'
+					) {
+						migrateEventsCounts++;
+					}
+				} );
+			} )
+			.then( () => {
+				expect( migrateEventsCounts ).to.equal( 1 );
+			} );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes

Added a cypress test case to verify Migration Event Reporting on Fork Step shows only once.
https://jira.newfold.com/browse/PRESS0-1954

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
