### PR TITLE
Fix/PRESS11-30 capabilities being checked on every pageload

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -14,6 +14,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 
+// Onboarding is only relevant to admins. This code should not run on every pageload.
+if ( ! current_user_can( 'manage_options' ) ) {
+	return;
+}
+
 /**
  * Register Onboarding with Newfold Module Loader
  *
@@ -76,4 +81,3 @@ add_action(
 );
 // Handle Module Disable if Non-Ecommerce
 ModuleController::init();
-}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -9,6 +9,11 @@ use NewfoldLabs\WP\Module\Onboarding\Compatibility\Status;
 
 use function NewfoldLabs\WP\ModuleLoader\register;
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
 /**
  * Register Onboarding with Newfold Module Loader
  *
@@ -65,11 +70,10 @@ function nfd_wp_module_onboarding_register() {
 /**
  * Tap WordPress Hooks to Instantiate Module Loader
  */
-if ( is_callable( 'add_action' ) ) {
-	add_action(
-		'plugins_loaded',
-		'nfd_wp_module_onboarding_register'
-	);
-	// Handle Module Disable if Non-Ecommerce
-	ModuleController::init();
+add_action(
+	'plugins_loaded',
+	'nfd_wp_module_onboarding_register'
+);
+// Handle Module Disable if Non-Ecommerce
+ModuleController::init();
 }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -14,11 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 
-// Onboarding is only relevant to admins. This code should not run on every pageload.
-if ( ! current_user_can( 'manage_options' ) ) {
-	return;
-}
-
 /**
  * Register Onboarding with Newfold Module Loader
  *

--- a/includes/ModuleController.php
+++ b/includes/ModuleController.php
@@ -33,10 +33,12 @@ class ModuleController {
 	 */
 	public static function module_switcher() {
 		$module_name = 'onboarding';
-		// Set brand context for the module.
-		$current_brand = Brands::set_current_brand( container() );
 
-		$enable_onboarding = self::verify_onboarding_criteria( $current_brand );
+		$enable_onboarding =
+			current_user_can( 'manage_options' )
+			&& self::verify_onboarding_criteria(
+				Brands::set_current_brand( container() )
+			);
 
 		// Check if he is a Non-Ecommerce Customer and Disable Redirect and Module
 		if ( ! $enable_onboarding ) {

--- a/includes/ModuleController.php
+++ b/includes/ModuleController.php
@@ -18,6 +18,8 @@ class ModuleController {
 
 	/**
 	 * Initialize the Module Controller functionality.
+	 *
+	 * @used-by wp-module-onboarding/bootstrap.php
 	 */
 	public static function init() {
 		// Enable/Disable the module after_setup_theme.
@@ -26,6 +28,8 @@ class ModuleController {
 
 	/**
 	 * Enable/Disable Onboarding based on certain checks.
+	 *
+	 * @hooked after_setup_theme
 	 */
 	public static function module_switcher() {
 		$module_name = 'onboarding';


### PR DESCRIPTION
## Proposed changes

Currently, capabilities requests are being made even for logged out users loading the homepage. This adds a `current_user_can()` check on `$enable_onboarding` so it doesn't run unnecessarily and make requests.

https://jira.newfold.com/browse/PRESS11-30

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

* I first tried to do this in `bootstrap.php` but `current_user_can()`'s `wp_get_current_user()` function had not yet been loaded. Hence the changes to that file.
