### PR TITLE
Revert "Fix/PRESS11-30 capabilities being checked on every pageload"

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -9,11 +9,6 @@ use NewfoldLabs\WP\Module\Onboarding\Compatibility\Status;
 
 use function NewfoldLabs\WP\ModuleLoader\register;
 
-// Exit if accessed directly.
-if ( ! defined( 'ABSPATH' ) ) {
-	return;
-}
-
 /**
  * Register Onboarding with Newfold Module Loader
  *
@@ -70,9 +65,11 @@ function nfd_wp_module_onboarding_register() {
 /**
  * Tap WordPress Hooks to Instantiate Module Loader
  */
-add_action(
-	'plugins_loaded',
-	'nfd_wp_module_onboarding_register'
-);
-// Handle Module Disable if Non-Ecommerce
-ModuleController::init();
+if ( is_callable( 'add_action' ) ) {
+	add_action(
+		'plugins_loaded',
+		'nfd_wp_module_onboarding_register'
+	);
+	// Handle Module Disable if Non-Ecommerce
+	ModuleController::init();
+}

--- a/includes/ModuleController.php
+++ b/includes/ModuleController.php
@@ -18,8 +18,6 @@ class ModuleController {
 
 	/**
 	 * Initialize the Module Controller functionality.
-	 *
-	 * @used-by wp-module-onboarding/bootstrap.php
 	 */
 	public static function init() {
 		// Enable/Disable the module after_setup_theme.
@@ -28,17 +26,13 @@ class ModuleController {
 
 	/**
 	 * Enable/Disable Onboarding based on certain checks.
-	 *
-	 * @hooked after_setup_theme
 	 */
 	public static function module_switcher() {
 		$module_name = 'onboarding';
+		// Set brand context for the module.
+		$current_brand = Brands::set_current_brand( container() );
 
-		$enable_onboarding =
-			current_user_can( 'manage_options' )
-			&& self::verify_onboarding_criteria(
-				Brands::set_current_brand( container() )
-			);
+		$enable_onboarding = self::verify_onboarding_criteria( $current_brand );
 
 		// Check if he is a Non-Ecommerce Customer and Disable Redirect and Module
 		if ( ! $enable_onboarding ) {


### PR DESCRIPTION
Reverts newfold-labs/wp-module-onboarding#628

This PR is being reverted because users are not being redirected to onboarding now, as the checks are not happening in the first place, however it only works when we click on Edit WordPress Site again.

CC: @diwanshuster @BrianHenryIE @wpscholar 