### PR TITLE
chore(i18n): align Composer i18n scripts with WP-CLI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,115 +1,116 @@
 {
-	"name": "newfold-labs/wp-module-onboarding",
-	"description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
-	"type": "library",
-	"license": "GPL-2.0-or-later",
-	"authors": [
-		{
-			"name": "Dave Ryan",
-			"email": "dave@bluehost.com"
-		}
-	],
-	"autoload": {
-		"psr-4": {
-			"NewfoldLabs\\WP\\Module\\Onboarding\\": "includes/"
-		},
-		"files": [
-			"bootstrap.php"
-		]
-	},
-	"config": {
-		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true,
-			"composer/installers": true,
-			"johnpbloch/wordpress-core-installer": true
-		},
-		"platform": {
-			"php": "7.4"
-		}
-	},
-	"repositories": {
-		"outlandishideas/wpackagist": {
-			"type": "composer",
-			"url": "https://wpackagist.org"
-		},
-		"0": {
-			"type": "composer",
-			"url": "https://newfold-labs.github.io/satis/",
-			"only": [
-				"newfold-labs/*"
-			]
-		},
-		"1": {
-			"type": "vcs",
-			"url": "git@github.com:InstaWP/connect-helpers.git",
-			"only": [
-				"instawp/*"
-			]
-		}
-	},
-	"require": {
-		"mustache/mustache": "^2.14.2",
-		"wp-cli/wp-config-transformer": "^1.4.5",
-		"newfold-labs/wp-module-onboarding-data": "^1.2.23",
-		"newfold-labs/wp-module-patterns": "^2.12.2",
-		"newfold-labs/wp-module-facebook": "^1.3.3",
-		"newfold-labs/wp-module-migration": "^1.7.1",
-		"wp-forge/helpers": "^2.0"
-	},
-	"require-dev": {
-		"php": ">=7.4",
-		"wp-phpunit/wp-phpunit": "^6.9.4",
-		"yoast/phpunit-polyfills": "^4.0.0",
-		"newfold-labs/wp-php-standards": "^1.2.5",
-		"wp-cli/i18n-command": "^2.7.0",
-		"johnpbloch/wordpress": "6.9.4",
-		"lucatume/wp-browser": "*",
-		"phpunit/phpcov": "*"
-	},
-	"scripts": {
-		"fix": [
-			"vendor/bin/phpcbf . --standard=phpcs.xml"
-		],
-		"i18n-pot": "vendor/bin/wp i18n make-pot . ./languages/wp-module-onboarding.pot --domain=wp-module-onboarding --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-onboarding/issues\",\"POT-Creation-Date\":\"2024-11-18T07:59:34+00:00\"}' --exclude=assets,tests,src,wordpress",
-		"i18n-po": "vendor/bin/wp i18n update-po ./languages/wp-module-onboarding.pot ./languages",
-		"i18n-mo": "vendor/bin/wp i18n make-mo ./languages",
-		"i18n-php": "vendor/bin/wp i18n make-php ./languages",
-		"i18n-json": "find ./languages -type f -name \"*.po\" -print0 | xargs -0 -I {} sh -c 'name=$(basename \"$1\" .po); npx po2json languages/\"$name\".po languages/\"$name\"-nfd-onboarding.json -f jed1.x' -- {}",
-		"i18n": [
-			"@i18n-pot",
-			"@i18n-po",
-			"@i18n-php",
-			"@i18n-json"
-		],
-		"i18n-ci-pre": [
-			"@i18n-pot",
-			"@i18n-po"
-		],
-		"i18n-ci-post": [
-			"@i18n-json",
-			"@i18n-php"
-		],
-		"lint": [
-			"vendor/bin/phpcs . --standard=phpcs.xml"
-		],
-		"test": [
-			"codecept run wpunit"
-		],
-		"test-coverage": [
-			"codecept run wpunit --coverage wpunit.cov",
-			"phpcov merge --php tests/_output/merged.cov --html tests/_output/html tests/_output;",
-			"echo \"open tests/_output/html/index.html\" to view the report"
-		]
-	},
-	"scripts-descriptions": {
-		"clean": "Automatically fix coding standards issues where possible.",
-		"i18n": "Generate new language files.",
-		"i18n-json": "Generate new language .json files.",
-		"i18n-mo": "Generate new language .mo files.",
-		"i18n-po": "Update existing .po files.",
-		"i18n-pot": "Generate a .pot file for translation.",
-		"lint": "Check files against coding standards.",
-		"test": "Run tests.",
-		"test-coverage": "Run tests with coverage, merge coverage and create HTML report."
-	}
+  "name": "newfold-labs/wp-module-onboarding",
+  "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
+  "type": "library",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Dave Ryan",
+      "email": "dave@bluehost.com"
+    }
+  ],
+  "autoload": {
+    "psr-4": {
+      "NewfoldLabs\\WP\\Module\\Onboarding\\": "includes/"
+    },
+    "files": [
+      "bootstrap.php"
+    ]
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "composer/installers": true,
+      "johnpbloch/wordpress-core-installer": true
+    },
+    "platform": {
+      "php": "7.4"
+    }
+  },
+  "repositories": {
+    "outlandishideas/wpackagist": {
+      "type": "composer",
+      "url": "https://wpackagist.org"
+    },
+    "0": {
+      "type": "composer",
+      "url": "https://newfold-labs.github.io/satis/",
+      "only": [
+        "newfold-labs/*"
+      ]
+    },
+    "1": {
+      "type": "vcs",
+      "url": "git@github.com:InstaWP/connect-helpers.git",
+      "only": [
+        "instawp/*"
+      ]
+    }
+  },
+  "require": {
+    "mustache/mustache": "^2.14.2",
+    "wp-cli/wp-config-transformer": "^1.4.5",
+    "newfold-labs/wp-module-onboarding-data": "^1.2.23",
+    "newfold-labs/wp-module-patterns": "^2.12.2",
+    "newfold-labs/wp-module-facebook": "^1.3.3",
+    "newfold-labs/wp-module-migration": "^1.7.1",
+    "wp-forge/helpers": "^2.0"
+  },
+  "require-dev": {
+    "php": ">=7.4",
+    "wp-phpunit/wp-phpunit": "^6.9.4",
+    "yoast/phpunit-polyfills": "^4.0.0",
+    "newfold-labs/wp-php-standards": "^1.2.5",
+    "wp-cli/i18n-command": "^2.7.0",
+    "johnpbloch/wordpress": "6.9.4",
+    "lucatume/wp-browser": "*",
+    "phpunit/phpcov": "*"
+  },
+  "scripts": {
+    "fix": [
+      "vendor/bin/phpcbf . --standard=phpcs.xml"
+    ],
+    "i18n-pot": "vendor/bin/wp i18n make-pot . ./languages/wp-module-onboarding.pot --domain=wp-module-onboarding --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-onboarding/issues\",\"POT-Creation-Date\":\"2024-11-18T07:59:34+00:00\"}' --exclude=assets,tests,src,wordpress",
+    "i18n-po": "vendor/bin/wp i18n update-po ./languages/wp-module-onboarding.pot ./languages",
+    "i18n-php": "vendor/bin/wp i18n make-php ./languages --pretty-print",
+    "i18n-json": "find ./languages -type f -name \"*.po\" -print0 | xargs -0 -I {} sh -c 'name=$(basename \"$1\" .po); npx po2json languages/\"$name\".po languages/\"$name\"-nfd-onboarding.json -f jed1.x' -- {}",
+    "i18n": [
+      "@i18n-pot",
+      "@i18n-po",
+      "@i18n-php",
+      "@i18n-json"
+    ],
+    "i18n-ci-pre": [
+      "@i18n-pot",
+      "@i18n-po"
+    ],
+    "i18n-ci-post": [
+      "@i18n-json",
+      "@i18n-php"
+    ],
+    "lint": [
+      "vendor/bin/phpcs . --standard=phpcs.xml"
+    ],
+    "test": [
+      "codecept run wpunit"
+    ],
+    "test-coverage": [
+      "codecept run wpunit --coverage wpunit.cov",
+      "phpcov merge --php tests/_output/merged.cov --html tests/_output/html tests/_output;",
+      "echo \"open tests/_output/html/index.html\" to view the report"
+    ]
+  },
+  "scripts-descriptions": {
+    "fix": "Automatically fix coding standards issues where possible.",
+    "i18n-pot": "Scan source and generate the POT translation template using wp i18n make-pot.",
+    "i18n-po": "Update PO files from the POT file using wp i18n update-po.",
+    "i18n-php": "Generate PHP translation files from PO files using wp i18n make-php.",
+    "i18n-json": "Generate JED JSON from PO files using npx po2json (per locale).",
+    "i18n": "Run the full local i18n pipeline (POT, PO, PHP, JSON).",
+    "i18n-ci-pre": "CI: regenerate the POT file and sync PO catalogs from it.",
+    "i18n-ci-post": "CI: regenerate JED JSON and PHP translation files from PO catalogs.",
+    "lint": "Check files against coding standards.",
+    "test": "Run tests.",
+    "test-coverage": "Run tests with coverage, merge coverage and create HTML report."
+  }
 }


### PR DESCRIPTION
## Summary
Align `composer.json` i18n scripts with current WP-CLI i18n behavior (org standardization).

## Changes
- Remove `--no-purge` from `wp i18n make-json` where present; keep `rm -f languages/*.json &&` before `make-json` (orphan Jed JSON cleanup).
- Add `--pretty-print` to `wp i18n make-php` where missing.
- Remove `i18n-mo` / `make-mo` and `@i18n-mo` from script chains.
- Add or refresh `scripts-descriptions` so every `scripts` entry is documented.

## Verification
- `composer validate`
- `composer run-script --list`