### PR TITLE
Refactor generation task progress for sitekit sub-step streaming

### DIFF
--- a/src/app/components/progress/TaskProgress.jsx
+++ b/src/app/components/progress/TaskProgress.jsx
@@ -28,10 +28,11 @@ const STATUS_CLASS = {
  * @param {Object}  props                 - The component props.
  * @param {string}  props.title           - Title shown when expanded.
  * @param {Array}   props.tasks           - Array of { key, label, status, result } objects.
- * @param {boolean} props.defaultExpanded - Whether to start expanded (default: false).
+ * @param {boolean}                       props.defaultExpanded - Whether to start expanded (default: false).
+ * @param {'discovery'|'generation'} props.variant          - Render variant (default: 'discovery').
  * @return {JSX.Element} The TaskProgress component.
  */
-const TaskProgress = ( { title, tasks = [], defaultExpanded = false } ) => {
+const TaskProgress = ( { title, tasks = [], defaultExpanded = false, variant = 'discovery' } ) => {
 	const isActive = tasks.some( ( t ) => t.status === 'running' || t.status === 'pending' );
 	const allDone =
 		tasks.length > 0 && tasks.every( ( t ) => t.status === 'done' || t.status === 'skipped' );
@@ -101,19 +102,25 @@ const TaskProgress = ( { title, tasks = [], defaultExpanded = false } ) => {
 									}` }
 								>
 									<TaskStatusIcon status={ task.status } />
-									<div className="nfd-flex nfd-flex-col nfd-gap-1 nfd-min-w-0">
-										<span className="nfd-font-medium">{ task.label }</span>
-										{ task.status === 'running' && task.description && (
-											<span className="nfd-font-normal nfd-text-xs nfd-leading-5 nfd-text-[rgba(0,0,0,0.4)]">
-												{ task.description }
-											</span>
-										) }
-										{ task.status === 'done' && task.result && (
-											<span className="nfd-font-normal nfd-text-sm nfd-leading-5 nfd-text-[rgba(0,0,0,0.45)]">
-												{ task.result }
-											</span>
-										) }
-									</div>
+									{ variant === 'discovery' ? (
+										<div className="nfd-flex nfd-flex-col nfd-gap-1 nfd-min-w-0">
+											<span className="nfd-font-medium">{ task.label }</span>
+											{ task.status === 'done' && task.result && (
+												<span className="nfd-font-normal nfd-text-xs nfd-leading-5 nfd-text-[rgba(0,0,0,0.4)]">
+													{ task.result }
+												</span>
+											) }
+										</div>
+									) : (
+										<div className="nfd-flex nfd-items-baseline nfd-gap-1.5 nfd-min-w-0">
+											<span className="nfd-font-medium">{ task.label }</span>
+											{ task.status === 'running' && task.description && (
+												<span className="nfd-font-normal nfd-text-xs nfd-text-[rgba(0,0,0,0.4)]">
+													{ task.description }
+												</span>
+											) }
+										</div>
+									) }
 								</li>
 							) ) }
 						</ul>

--- a/src/app/hooks/chat/tasks.js
+++ b/src/app/hooks/chat/tasks.js
@@ -1,71 +1,53 @@
 export const MAX_RETRIES = 3;
 
 /**
- * The 5 discovery sub-tasks fired concurrently by the AI platform.
+ * The discovery sub-tasks fired concurrently by the AI platform.
  */
 export const DISCOVERY_TASKS = [
 	{
 		key: 'prompt_enhance',
 		label: 'Understanding your site',
+		description: 'Analyzing your site description...',
 		event: 'sitegen_discovery_prompt_enhance_completed',
 	},
 	{
 		key: 'site_type',
 		label: 'Identifying site type',
+		description: 'Determining the best category for your site...',
 		event: 'sitegen_discovery_site_type_completed',
 	},
 	{
 		key: 'keywords',
 		label: 'Generating keywords',
+		description: 'Finding relevant keywords for your content...',
 		event: 'sitegen_discovery_keywords_completed',
-	},
-	{
-		key: 'sitemap',
-		label: 'Building sitemap',
-		event: 'sitegen_discovery_sitemap_completed',
 	},
 	{
 		key: 'brand_identity',
 		label: 'Crafting brand identity',
+		description: 'Defining your brand voice and personality...',
 		event: 'sitegen_discovery_brand_identity_completed',
 	},
 ];
 
 /**
- * The 4 generation sub-tasks shown while site content is built.
+ * The generation tasks shown while site content is built.
  */
 export const GENERATION_TASKS = [
-	{
-		key: 'template',
-		label: 'Designing your website',
-		description: 'Designing the best layout for your site type...',
-	},
-	{
-		key: 'fonts',
-		label: 'Picking the right typography',
-		description: 'Selecting font pairings that fit your brand...',
-	},
-	{
-		key: 'colors',
-		label: 'Creating color palette',
-		description: 'Designing brand colors that match your identity...',
-	},
-	{
-		key: 'logo',
-		label: 'Generating logo',
-		description: 'Creating a logo for your brand...',
-	},
-	{
-		key: 'post_types',
-		label: 'Setting up content',
-		description: 'Configuring post types and products...',
-	},
+	{ key: 'sitekit_selected', label: 'Designing layout', description: 'Finding the ideal design for your site...' },
+	{ key: 'colors', label: 'Creating color palette', description: 'Designing brand colors that match your identity...' },
+	{ key: 'font_pair', label: 'Choosing typography', description: 'Selecting font pairings that fit your brand...' },
+	{ key: 'logo', label: 'Generating logo', description: 'Creating a logo for your brand...' },
+	{ key: 'sitemap', label: 'Planning site pages', description: 'Mapping out pages for your site...' },
+	{ key: 'site_content', label: 'Building site content', description: 'Generating page content and structure...' },
+	{ key: 'post_types', label: 'Setting up content', description: 'Configuring post types and products...' },
 ];
 
 export function createInitialTasks() {
 	return DISCOVERY_TASKS.map( ( t ) => ( {
 		key: t.key,
 		label: t.label,
+		description: t.description,
 		status: 'pending',
 		result: null,
 	} ) );
@@ -90,9 +72,10 @@ export const EVENT_TO_TASK_KEY = DISCOVERY_TASKS.reduce( ( map, t ) => {
  * Map backend generation item event keys to frontend GENERATION_TASKS keys.
  * Backend emits: sitegen_content_generation_item{key}_completed
  */
+export const GENERATION_TASK_KEYS = new Set( GENERATION_TASKS.map( ( t ) => t.key ) );
+
 export const GENERATION_ITEM_KEY_MAP = {
-	sitekit: 'template',
-	site_fonts: 'fonts',
+	sitekit: 'site_content',
 	site_colors: 'colors',
 	site_logo: 'logo',
 	post_types: 'post_types',

--- a/src/app/hooks/useChat.js
+++ b/src/app/hooks/useChat.js
@@ -22,6 +22,7 @@ import {
 	MAX_RETRIES,
 	EVENT_TO_TASK_KEY,
 	GENERATION_ITEM_KEY_MAP,
+	GENERATION_TASK_KEYS,
 	createInitialTasks,
 	createGenerationTasks,
 } from '@/hooks/chat/tasks';
@@ -114,7 +115,6 @@ const useChat = () => {
 					if ( discoveryTaskKey ) {
 						if (
 							discoveryTaskKey === 'brand_identity' ||
-							discoveryTaskKey === 'sitemap' ||
 							discoveryTaskKey === 'site_type'
 						) {
 							try {
@@ -162,6 +162,12 @@ const useChat = () => {
 						if ( taskKey ) {
 							completeTask( generationMsgId, taskKey, 'Done' );
 						}
+						return;
+					}
+
+					const sitekitStepMatch = event.match( /^sitegen_sitekit_step_(.+)$/ );
+					if ( sitekitStepMatch && generationMsgId && GENERATION_TASK_KEYS.has( sitekitStepMatch[ 1 ] ) ) {
+						completeTask( generationMsgId, sitekitStepMatch[ 1 ], 'Done' );
 						return;
 					}
 

--- a/src/app/views/ChatView.js
+++ b/src/app/views/ChatView.js
@@ -34,6 +34,7 @@ const ChatView = ( {
 								key={ msg.id }
 								title={ msg.title }
 								tasks={ msg.tasks }
+								variant={ msg.role }
 							/>
 						);
 					}


### PR DESCRIPTION
## Summary
- Wire up new `sitegen_sitekit_step_*` SSE events for granular sitekit progress updates
- Reorder generation tasks to a logical flow: layout → colors → typography → logo → sitemap → content → post types
- Add `variant` prop to `TaskProgress` for distinct discovery vs generation rendering
- Remove dead `sitemap` reference from discovery data handler
- Validate sitekit step keys against known generation task keys before completing tasks
- Remove separate `site_fonts` and `sitemap` discovery tasks (now handled as sitekit sub-steps)

Companion PR: https://github.com/newfold-labs/ai-platform/pull/7

## Test plan
- [ ] Verify discovery progress panel still works correctly
- [ ] Confirm generation tasks complete in response to `sitegen_sitekit_step_*` events
- [ ] Check that unknown sitekit step keys are silently ignored
- [ ] Verify task list renders in the new logical order