### PR TITLE
Onboarding: SiteGen published/selected logic

### DIFF
--- a/includes/Data/Options.php
+++ b/includes/Data/Options.php
@@ -61,13 +61,18 @@ final class Options {
 		'wc_queue_flush_rewrite_rules'  => 'woocommerce_queue_flush_rewrite_rules',
 		'bluehost_plugin_install_date'  => 'bluehost_plugin_install_date',
 		'state_input'                   => 'state_input',
-		'state_sitegen'                 => 'state_sitegen',
 		'state_logogen'                 => 'state_logogen',
 		'state_blueprints'              => 'state_blueprints',
 		'sitegen_previews'              => 'sitegen_previews',
 		'site_info'                     => 'site_info',
 		'start_time'                    => 'start_time',
 		'completed_time'                => 'completed_time',
+		'sitegen_site_id'               => 'sitegen_site_id',
+		'sitegen_current_id'            => 'sitegen_current_id',
+		'sitegen_previous_ids'          => 'sitegen_previous_ids',
+		'sitegen_site_type'             => 'sitegen_site_type',
+		'sitegen_enhanced_prompt'       => 'sitegen_enhanced_prompt',
+		'sitegen_discovery_data'        => 'sitegen_discovery_data',
 	);
 
 	/**

--- a/includes/Data/Options.php
+++ b/includes/Data/Options.php
@@ -67,9 +67,7 @@ final class Options {
 		'sitegen_previews'              => 'sitegen_previews',
 		'site_info'                     => 'site_info',
 		'start_time'                    => 'start_time',
-		'completed_time'                => 'completed_time',
-		'sitegen_site_id'               => 'sitegen_site_id',
-		'sitegen_id'                    => 'sitegen_id',
+		'completed_time'                => 'completed_time'
 	);
 
 	/**

--- a/includes/Data/Options.php
+++ b/includes/Data/Options.php
@@ -68,7 +68,8 @@ final class Options {
 		'site_info'                     => 'site_info',
 		'start_time'                    => 'start_time',
 		'completed_time'                => 'completed_time',
-		'ai_sitegen_site_id'            => 'ai_sitegen_site_id',
+		'sitegen_site_id'               => 'sitegen_site_id',
+		'sitegen_id'                    => 'sitegen_id',
 	);
 
 	/**

--- a/includes/Data/Options.php
+++ b/includes/Data/Options.php
@@ -68,6 +68,7 @@ final class Options {
 		'site_info'                     => 'site_info',
 		'start_time'                    => 'start_time',
 		'completed_time'                => 'completed_time',
+		'ai_sitegen_site_id'            => 'ai_sitegen_site_id',
 	);
 
 	/**

--- a/includes/RestApi/ReduxStateController.php
+++ b/includes/RestApi/ReduxStateController.php
@@ -149,15 +149,13 @@ class ReduxStateController {
 	/**
 	 * Get the sitegen slice state.
 	 *
+	 * Reconstructs the slice from individual dedicated options.
+	 * state_sitegen is no longer used as the primary storage.
+	 *
 	 * @return \WP_REST_Response
 	 */
-	public function get_sitegen_slice_state() {
-		$data = \get_option( Options::get_option_name( 'state_sitegen' ), false );
-		if ( ! $data ) {
-			$data = array();
-		}
-
-		return new \WP_REST_Response( $data, 200 );
+	public function get_sitegen_slice_state(): \WP_REST_Response {
+		return new \WP_REST_Response( ReduxStateService::get( 'sitegen' ), 200 );
 	}
 
 	/**
@@ -175,12 +173,37 @@ class ReduxStateController {
 			);
 		}
 
-		$result = ReduxStateService::update( 'sitegen', $data );
-		if ( ! $result ) {
-			return new \WP_REST_Response(
-				'Failed to update sitegen slice state',
-				500
-			);
+		if ( ! empty( $data['siteId'] ) ) {
+			update_option( Options::get_option_name( 'sitegen_site_id' ), $data['siteId'] );
+		}
+
+		if ( ! empty( $data['siteGenId'] ) ) {
+			$current = get_option( Options::get_option_name( 'sitegen_current_id' ), '' );
+			if ( $current && $current !== $data['siteGenId'] ) {
+				$previous = get_option( Options::get_option_name( 'sitegen_previous_ids' ), array() );
+				if ( ! is_array( $previous ) ) {
+					$previous = array();
+				}
+				if ( ! in_array( $current, $previous, true ) ) {
+					$previous[] = $current;
+				}
+				update_option( Options::get_option_name( 'sitegen_previous_ids' ), $previous );
+			}
+			update_option( Options::get_option_name( 'sitegen_current_id' ), $data['siteGenId'] );
+		}
+
+		// site_type
+		if ( ! empty( $data['siteType'] ) ) {
+			update_option( Options::get_option_name( 'sitegen_site_type' ), $data['siteType'] );
+		}
+
+		// enhanced_prompt
+		if ( ! empty( $data['enhancedPrompt'] ) ) {
+			update_option( Options::get_option_name( 'sitegen_enhanced_prompt' ), $data['enhancedPrompt'] );
+		}
+
+		if ( ! empty( $data['discoveryData'] ) ) {
+			update_option( Options::get_option_name( 'sitegen_discovery_data' ), $data['discoveryData'] );
 		}
 
 		return new \WP_REST_Response( $data, 200 );

--- a/includes/RestApi/RestApi.php
+++ b/includes/RestApi/RestApi.php
@@ -23,6 +23,7 @@ final class RestApi {
 		'NewfoldLabs\\WP\\Module\\Onboarding\\RestApi\\DesignController',
 		'NewfoldLabs\\WP\\Module\\Onboarding\\RestApi\\GlobalStylesController',
 		'NewfoldLabs\\WP\\Module\\Onboarding\\RestApi\\SiteContentController',
+		'NewfoldLabs\\WP\\Module\\Onboarding\\RestApi\\SiteGenAiController',
 	);
 
 	/**

--- a/includes/RestApi/SiteGenAiController.php
+++ b/includes/RestApi/SiteGenAiController.php
@@ -72,7 +72,7 @@ class SiteGenAiController {
 		$options = $request->get_param( 'options' );
 		foreach ( $options as $key => $value ) {
 			$option_name = Options::get_option_name( $key );
-			
+
 			if ( false !== $option_name ) {
 				\update_option( $option_name, $value );
 			}

--- a/includes/RestApi/SiteGenAiController.php
+++ b/includes/RestApi/SiteGenAiController.php
@@ -1,0 +1,87 @@
+<?php
+namespace NewfoldLabs\WP\Module\Onboarding\RestApi;
+
+use NewfoldLabs\WP\Module\Onboarding\Permissions;
+use NewfoldLabs\WP\Module\Onboarding\Data\Options;
+use NewfoldLabs\WP\Module\Onboarding\Services\Ai\SiteGenServiceRequest;
+
+/**
+ * Class SiteGenAiController
+ */
+class SiteGenAiController {
+	/**
+	 * The namespace of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'newfold-onboarding/v1';
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = '/sitegen';
+
+	/**
+	 * Registers rest routes for SiteGenAiController class.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+
+		\register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/ai-site-id',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'save_ai_site_id' ),
+					'permission_callback' => array( Permissions::class, 'rest_is_authorized_admin' ),
+				),
+			)
+		);
+
+		\register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/report-published',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'report_published' ),
+					'permission_callback' => array( Permissions::class, 'rest_is_authorized_admin' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Save the AI site ID.
+	 *
+	 * @param \WP_REST_Request $request The REST request object.
+	 * @return \WP_REST_Response
+	 */
+	public function save_ai_site_id( \WP_REST_Request $request ): \WP_REST_Response {
+		$site_id = $request->get_param( 'site_id' );
+		\update_option( Options::get_option_name( 'ai_sitegen_site_id' ), $site_id );
+		return new \WP_REST_Response( array( 'status' => 'ok' ), 200 );
+	}
+
+	/**
+	 * Report the published site.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function report_published(): \WP_REST_Response {
+		$site_id = \get_option( Options::get_option_name( 'ai_sitegen_site_id' ) );
+
+		if ( ! $site_id ) {
+			return new \WP_REST_Response( array( 'status' => 'no_site_id' ), 200 );
+		}
+
+		$ai_request = new SiteGenServiceRequest( 'sitegen/select', array( 'site_id' => $site_id ) );
+		$ai_request->send_async();
+
+		return new \WP_REST_Response( array( 'status' => 'reported' ), 200 );
+	}
+}

--- a/includes/RestApi/SiteGenAiController.php
+++ b/includes/RestApi/SiteGenAiController.php
@@ -32,12 +32,18 @@ class SiteGenAiController {
 
 		\register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/ai-site-id',
+			$this->rest_base . '/options',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'save_ai_site_id' ),
+					'callback'            => array( $this, 'save_sitegen_options' ),
 					'permission_callback' => array( Permissions::class, 'rest_is_authorized_admin' ),
+					'args'                => array(
+						'options' => array(
+							'type'     => 'object',
+							'required' => true,
+						),
+					),
 				),
 			)
 		);
@@ -56,14 +62,21 @@ class SiteGenAiController {
 	}
 
 	/**
-	 * Save the AI site ID.
+	 * Save the options.
 	 *
 	 * @param \WP_REST_Request $request The REST request object.
+	 *
 	 * @return \WP_REST_Response
 	 */
-	public function save_ai_site_id( \WP_REST_Request $request ): \WP_REST_Response {
-		$site_id = $request->get_param( 'site_id' );
-		\update_option( Options::get_option_name( 'ai_sitegen_site_id' ), $site_id );
+	public function save_sitegen_options( \WP_REST_Request $request ): \WP_REST_Response {
+		$options = $request->get_param( 'options' );
+		foreach ( $options as $key => $value ) {
+			$option_name = Options::get_option_name( $key );
+			
+			if ( false !== $option_name ) {
+				\update_option( $option_name, $value );
+			}
+		}
 		return new \WP_REST_Response( array( 'status' => 'ok' ), 200 );
 	}
 
@@ -73,13 +86,14 @@ class SiteGenAiController {
 	 * @return \WP_REST_Response
 	 */
 	public function report_published(): \WP_REST_Response {
-		$site_id = \get_option( Options::get_option_name( 'ai_sitegen_site_id' ) );
+		$sitegen_id = \get_option( Options::get_option_name( 'sitegen_id' ) );
 
-		if ( ! $site_id ) {
+		if ( ! $sitegen_id ) {
 			return new \WP_REST_Response( array( 'status' => 'no_site_id' ), 200 );
 		}
 
-		$ai_request = new SiteGenServiceRequest( 'sitegen/select', array( 'site_id' => $site_id ) );
+		$ai_request = new SiteGenServiceRequest( 'sitegen/select', array( 'sitegen_id' => $sitegen_id ) );
+
 		$ai_request->send_async();
 
 		return new \WP_REST_Response( array( 'status' => 'reported' ), 200 );

--- a/includes/RestApi/SiteGenAiController.php
+++ b/includes/RestApi/SiteGenAiController.php
@@ -4,6 +4,7 @@ namespace NewfoldLabs\WP\Module\Onboarding\RestApi;
 use NewfoldLabs\WP\Module\Onboarding\Permissions;
 use NewfoldLabs\WP\Module\Onboarding\Services\ReduxStateService;
 use NewfoldLabs\WP\Module\Onboarding\Services\Ai\SiteGenServiceRequest;
+use NewfoldLabs\WP\Module\Onboarding\Data\Options;
 
 /**
  * Class SiteGenAiController
@@ -81,14 +82,12 @@ class SiteGenAiController {
 	 * @return \WP_REST_Response
 	 */
 	public function report_published(): \WP_REST_Response {
-		$state      = ReduxStateService::get( 'sitegen' );
-		$sitegen_id = $state['siteGenId'] ?? null;
+		$sitegen_id = get_option( Options::get_option_name( 'sitegen_current_id' ), '' );
 		if ( ! $sitegen_id ) {
 			return new \WP_REST_Response( array( 'status' => 'no_site_id' ), 200 );
 		}
 
 		$ai_request = new SiteGenServiceRequest( 'sitegen/select', array( 'sitegen_id' => $sitegen_id ) );
-
 		$ai_request->send_async();
 
 		return new \WP_REST_Response( array( 'status' => 'reported' ), 200 );

--- a/includes/RestApi/SiteGenAiController.php
+++ b/includes/RestApi/SiteGenAiController.php
@@ -2,7 +2,7 @@
 namespace NewfoldLabs\WP\Module\Onboarding\RestApi;
 
 use NewfoldLabs\WP\Module\Onboarding\Permissions;
-use NewfoldLabs\WP\Module\Onboarding\Data\Options;
+use NewfoldLabs\WP\Module\Onboarding\Services\ReduxStateService;
 use NewfoldLabs\WP\Module\Onboarding\Services\Ai\SiteGenServiceRequest;
 
 /**
@@ -32,18 +32,12 @@ class SiteGenAiController {
 
 		\register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/options',
+			$this->rest_base . '/handshake',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'save_sitegen_options' ),
+					'callback'            => array( $this, 'handshake' ),
 					'permission_callback' => array( Permissions::class, 'rest_is_authorized_admin' ),
-					'args'                => array(
-						'options' => array(
-							'type'     => 'object',
-							'required' => true,
-						),
-					),
 				),
 			)
 		);
@@ -62,22 +56,23 @@ class SiteGenAiController {
 	}
 
 	/**
-	 * Save the options.
-	 *
-	 * @param \WP_REST_Request $request The REST request object.
+	 * Handshake with the AI platform.
 	 *
 	 * @return \WP_REST_Response
 	 */
-	public function save_sitegen_options( \WP_REST_Request $request ): \WP_REST_Response {
-		$options = $request->get_param( 'options' );
-		foreach ( $options as $key => $value ) {
-			$option_name = Options::get_option_name( $key );
-
-			if ( false !== $option_name ) {
-				\update_option( $option_name, $value );
-			}
+	public function handshake(): \WP_REST_Response {
+		$request = new SiteGenServiceRequest(
+			'sitegen/handshake',
+			array( 'domain' => \home_url() )
+		);
+	
+		$response = $request->send();
+	
+		if ( ! $response || empty( $response['site_id'] ) ) {
+			return new \WP_REST_Response( array( 'error' => 'Handshake failed' ), 502 );
 		}
-		return new \WP_REST_Response( array( 'status' => 'ok' ), 200 );
+	
+		return new \WP_REST_Response( $response, 200 );
 	}
 
 	/**
@@ -86,8 +81,8 @@ class SiteGenAiController {
 	 * @return \WP_REST_Response
 	 */
 	public function report_published(): \WP_REST_Response {
-		$sitegen_id = \get_option( Options::get_option_name( 'sitegen_id' ) );
-
+		$state = ReduxStateService::get( 'sitegen' );
+		$sitegen_id = $state['siteGenId'] ?? null;
 		if ( ! $sitegen_id ) {
 			return new \WP_REST_Response( array( 'status' => 'no_site_id' ), 200 );
 		}

--- a/includes/Services/Ai/SiteGenServiceRequest.php
+++ b/includes/Services/Ai/SiteGenServiceRequest.php
@@ -9,12 +9,11 @@ namespace NewfoldLabs\WP\Module\Onboarding\Services\Ai;
 
 use NewfoldLabs\WP\Module\Data\HiiveConnection;
 
-use function cli\err;
-
 /**
  * SiteGenServiceRequest class.
  */
 class SiteGenServiceRequest {
+
 
 	/**
 	 * The default base URL.
@@ -45,19 +44,47 @@ class SiteGenServiceRequest {
 	protected $body;
 
 	/**
+	 * The SSL verify setting.
+	 *
+	 * @var bool
+	 */
+	protected $sslverify;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $endpoint The endpoint.
 	 * @param array  $body The body.
 	 */
 	public function __construct( string $endpoint, array $body ) {
-		$base          = defined( 'NFD_AI_PLATFORM_BASE_URL' ) ? NFD_AI_PLATFORM_BASE_URL : self::DEFAULT_BASE_URL;
-		$this->url     = rtrim( $base, '/' ) . '/api/v1/' . $endpoint;
-		$this->body    = $body;
-		$this->headers = array(
+		$base            = defined( 'NFD_AI_PLATFORM_BASE_URL' ) ? NFD_AI_PLATFORM_BASE_URL : self::DEFAULT_BASE_URL;
+		$this->sslverify = defined( 'NFD_AI_PLATFORM_SSL_VERIFY' ) ? NFD_AI_PLATFORM_SSL_VERIFY : true;
+		$this->url       = rtrim( $base, '/' ) . '/api/v1/' . $endpoint;
+		$this->body      = $body;
+		$this->headers   = array(
 			'Content-Type'  => 'application/json',
 			'Authorization' => 'Bearer ' . HiiveConnection::get_auth_token(),
 		);
+	}
+
+	/**
+	 * Send the request and return the response body.
+	 *
+	 * @return array|null Decoded response body or null on failure.
+	 */
+	public function send(): ?array {
+		$response = wp_remote_post(
+			$this->url,
+			$this->get_request_args()
+		);
+
+		
+		if ( \is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		return json_decode( $body, true );
 	}
 
 	/**
@@ -68,12 +95,22 @@ class SiteGenServiceRequest {
 	public function send_async(): void {
 		wp_remote_post(
 			$this->url,
-			array(
-				'headers'   => $this->headers,
-				'body'      => wp_json_encode( $this->body ),
-				'sslverify' => defined( 'NFD_AI_PLATFORM_SSL_VERIFY' ) ? NFD_AI_PLATFORM_SSL_VERIFY : true, // set to false in development environments.
-				'blocking'  => false, // The request is fire and forget. No waiting for AI Platform response and no action is needed on the response.
-			)
+			$this->get_request_args( false )
+		);
+	}
+
+	/**
+	 * Get the request arguments.
+	 *
+	 * @param bool $blocking Whether the request is blocking.
+	 * @return array The request arguments.
+	 */
+	private function get_request_args( $blocking = true ): array {
+		return array(
+			'headers'   => $this->headers,
+			'body'      => wp_json_encode( $this->body ),
+			'sslverify' => $this->sslverify,
+			'blocking'  => $blocking,
 		);
 	}
 }

--- a/includes/Services/Ai/SiteGenServiceRequest.php
+++ b/includes/Services/Ai/SiteGenServiceRequest.php
@@ -78,7 +78,6 @@ class SiteGenServiceRequest {
 			$this->get_request_args()
 		);
 
-		
 		if ( \is_wp_error( $response ) ) {
 			return null;
 		}

--- a/includes/Services/Ai/SiteGenServiceRequest.php
+++ b/includes/Services/Ai/SiteGenServiceRequest.php
@@ -66,6 +66,7 @@ class SiteGenServiceRequest {
 			array(
 				'headers'  => $this->headers,
 				'body'     => wp_json_encode( $this->body ),
+				'sslverify' => defined( 'NFD_AI_PLATFORM_SSL_VERIFY' ) ? NFD_AI_PLATFORM_SSL_VERIFY : true, //set to false in development environments.
 				'blocking' => false, // The request is fire and forget. No waiting for AI Platform response and no action is needed on the response.
 			)
 		);

--- a/includes/Services/Ai/SiteGenServiceRequest.php
+++ b/includes/Services/Ai/SiteGenServiceRequest.php
@@ -1,10 +1,15 @@
 <?php
 /**
  * SiteGenServiceRequest class.
+ *
+ * @package NewfoldLabs\WP\Module\Onboarding
  */
+
 namespace NewfoldLabs\WP\Module\Onboarding\Services\Ai;
 
 use NewfoldLabs\WP\Module\Data\HiiveConnection;
+
+use function cli\err;
 
 /**
  * SiteGenServiceRequest class.
@@ -23,21 +28,21 @@ class SiteGenServiceRequest {
 	 *
 	 * @var string
 	 */
-	protected string $url;
+	protected $url;
 
 	/**
 	 * The headers.
 	 *
 	 * @var array
 	 */
-	protected array $headers;
+	protected $headers;
 
 	/**
 	 * The body.
 	 *
 	 * @var array
 	 */
-	protected array $body;
+	protected $body;
 
 	/**
 	 * Constructor.
@@ -64,10 +69,10 @@ class SiteGenServiceRequest {
 		wp_remote_post(
 			$this->url,
 			array(
-				'headers'  => $this->headers,
-				'body'     => wp_json_encode( $this->body ),
-				'sslverify' => defined( 'NFD_AI_PLATFORM_SSL_VERIFY' ) ? NFD_AI_PLATFORM_SSL_VERIFY : true, //set to false in development environments.
-				'blocking' => false, // The request is fire and forget. No waiting for AI Platform response and no action is needed on the response.
+				'headers'   => $this->headers,
+				'body'      => wp_json_encode( $this->body ),
+				'sslverify' => defined( 'NFD_AI_PLATFORM_SSL_VERIFY' ) ? NFD_AI_PLATFORM_SSL_VERIFY : true, // set to false in development environments.
+				'blocking'  => false, // The request is fire and forget. No waiting for AI Platform response and no action is needed on the response.
 			)
 		);
 	}

--- a/includes/Services/Ai/SiteGenServiceRequest.php
+++ b/includes/Services/Ai/SiteGenServiceRequest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * SiteGenServiceRequest class.
+ */
+namespace NewfoldLabs\WP\Module\Onboarding\Services\Ai;
+
+use NewfoldLabs\WP\Module\Data\HiiveConnection;
+
+/**
+ * SiteGenServiceRequest class.
+ */
+class SiteGenServiceRequest {
+
+	/**
+	 * The default base URL.
+	 *
+	 * @var string
+	 */
+	const DEFAULT_BASE_URL = 'https://bluehost-ai-platform.on-forge.com';
+
+	/**
+	 * The URL.
+	 *
+	 * @var string
+	 */
+	protected string $url;
+
+	/**
+	 * The headers.
+	 *
+	 * @var array
+	 */
+	protected array $headers;
+
+	/**
+	 * The body.
+	 *
+	 * @var array
+	 */
+	protected array $body;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $endpoint The endpoint.
+	 * @param array  $body The body.
+	 */
+	public function __construct( string $endpoint, array $body ) {
+		$base          = defined( 'NFD_AI_PLATFORM_BASE_URL' ) ? NFD_AI_PLATFORM_BASE_URL : self::DEFAULT_BASE_URL;
+		$this->url     = rtrim( $base, '/' ) . '/api/v1/' . $endpoint;
+		$this->body    = $body;
+		$this->headers = array(
+			'Content-Type'  => 'application/json',
+			'Authorization' => 'Bearer ' . HiiveConnection::get_auth_token(),
+		);
+	}
+
+	/**
+	 * Send the request asynchronously.
+	 *
+	 * @return void
+	 */
+	public function send_async(): void {
+		wp_remote_post(
+			$this->url,
+			array(
+				'headers'  => $this->headers,
+				'body'     => wp_json_encode( $this->body ),
+				'blocking' => false, // The request is fire and forget. No waiting for AI Platform response and no action is needed on the response.
+			)
+		);
+	}
+}

--- a/includes/Services/ReduxStateService.php
+++ b/includes/Services/ReduxStateService.php
@@ -41,11 +41,35 @@ class ReduxStateService {
 			return $data;
 		}
 
-		$data = \get_option( Options::get_option_name( self::$states[ $state ] ), false );
+		$getter = 'get_' . self::$states[ $state ];
+
+		if ( is_callable( array( self::class, $getter ) ) ) {
+			$data = call_user_func( array( self::class, $getter ) );
+		} else {
+			$data = \get_option( Options::get_option_name( self::$states[ $state ] ), false );
+		}
+
 		if ( ! $data ) {
 			$data = array();
 		}
+
 		return $data;
+	}
+
+	/**
+	 * Get the sitegen slice reconstructed from individual dedicated options.
+	 *
+	 * @return array The sitegen slice data.
+	 */
+	public static function get_state_sitegen(): array {
+		return array(
+			'siteId'              => \get_option( Options::get_option_name( 'sitegen_site_id' ), '' ),
+			'siteGenId'           => \get_option( Options::get_option_name( 'sitegen_current_id' ), '' ),
+			'siteType'            => \get_option( Options::get_option_name( 'sitegen_site_type' ), '' ),
+			'enhancedPrompt'      => \get_option( Options::get_option_name( 'sitegen_enhanced_prompt' ), '' ),
+			'discoveryData'       => \get_option( Options::get_option_name( 'sitegen_discovery_data' ), array() ),
+			'sitegenSliceVersion' => 0,
+		);
 	}
 
 	/**

--- a/includes/Services/ResetService.php
+++ b/includes/Services/ResetService.php
@@ -76,12 +76,14 @@ class ResetService {
 
 	/**
 	 * Delete all onboarding-related options from the database.
+	 * Some options (e.g. sitegen state) are preserved.
 	 *
 	 * @return void
 	 */
 	private static function reset_onboarding_options(): void {
 		global $wpdb;
 		$prefixes = array( 'nfd_module_onboarding_', 'nfd-ai-site-gen' );
+		$excluded   = array( 'nfd_module_onboarding_state_sitegen' );
 
 		foreach ( $prefixes as $prefix ) {
 			$options = $wpdb->get_col(
@@ -96,6 +98,9 @@ class ResetService {
 			}
 
 			foreach ( $options as $option_name ) {
+				if ( in_array( $option_name, $excluded, true ) ) {
+					continue;
+				}
 				delete_option( $option_name );
 			}
 		}

--- a/includes/Services/ResetService.php
+++ b/includes/Services/ResetService.php
@@ -83,7 +83,7 @@ class ResetService {
 	private static function reset_onboarding_options(): void {
 		global $wpdb;
 		$prefixes = array( 'nfd_module_onboarding_', 'nfd-ai-site-gen' );
-		$excluded = array( 'nfd_module_onboarding_state_sitegen' );
+		$excluded = array( 'nfd_module_onboarding_sitegen_site_id', 'nfd_module_onboarding_sitegen_previous_ids' );
 
 		foreach ( $prefixes as $prefix ) {
 			$options = $wpdb->get_col(

--- a/includes/WP_Admin.php
+++ b/includes/WP_Admin.php
@@ -173,6 +173,7 @@ final class WP_Admin {
 
 			$nfd_onboarding_data = array(
 				'runtime' => Runtime::get_data(),
+				'sitegen' => ReduxStateService::get( 'sitegen' ),
 			);
 			\wp_add_inline_script(
 				self::$slug,

--- a/src/app/data/store/index.js
+++ b/src/app/data/store/index.js
@@ -2,10 +2,7 @@ import { createReduxStore, register } from '@wordpress/data';
 import actions from './actions';
 import selectors from './selectors';
 import reducer from './reducer';
-import { dbSyncService as inputSliceDbSyncService } from './slices/input';
 import { dbSyncService as sitegenSliceDbSyncService } from './slices/sitegen';
-import { dbSyncService as logogenSliceDbSyncService } from './slices/logogen';
-import { dbSyncService as blueprintsSliceDbSyncService } from './slices/blueprints';
 
 const STORE_NAME = 'newfold/onboarding';
 const STORE_CONFIG = {
@@ -21,8 +18,5 @@ register( nfdOnboardingStore );
  * Initialize the store-db sync services.
  */
 export function initializeStoreDbSyncServices() {
-	//inputSliceDbSyncService();
 	sitegenSliceDbSyncService();
-	//logogenSliceDbSyncService();
-	//blueprintsSliceDbSyncService();
 }

--- a/src/app/data/store/index.js
+++ b/src/app/data/store/index.js
@@ -21,8 +21,8 @@ register( nfdOnboardingStore );
  * Initialize the store-db sync services.
  */
 export function initializeStoreDbSyncServices() {
-	inputSliceDbSyncService();
+	//inputSliceDbSyncService();
 	sitegenSliceDbSyncService();
-	logogenSliceDbSyncService();
-	blueprintsSliceDbSyncService();
+	//logogenSliceDbSyncService();
+	//blueprintsSliceDbSyncService();
 }

--- a/src/app/data/store/slices/sitegen.js
+++ b/src/app/data/store/slices/sitegen.js
@@ -3,12 +3,8 @@ import { nfdOnboardingStore } from '@/data/store';
 import { updateOnboardingSiteGenSlice } from '@/utils/api';
 
 const DEFAULT_STATE = {
-	homepages: [],
-	selectedHomepage: '',
-	hasGeneratedSitePages: false,
-	retryMode: false,
-	sitegenHasFailed: false,
-	canvasSidebarIsOpen: true,
+	siteId: '',
+	siteGenId: '',
 	sitegenSliceVersion: 0,
 };
 
@@ -27,40 +23,16 @@ export function sitegen( state = DEFAULT_STATE, action ) {
 				...action.siteGenSlice,
 				sitegenSliceVersion: state.sitegenSliceVersion + 1,
 			};
-		case 'SET_HOMEPAGES':
+		case 'SET_SITE_ID':
 			return {
 				...state,
-				homepages: action.homepages,
+				siteId: action.siteId,
 				sitegenSliceVersion: state.sitegenSliceVersion + 1,
 			};
-		case 'SET_SELECTED_HOMEPAGE':
+		case 'SET_SITE_GEN_ID':
 			return {
 				...state,
-				selectedHomepage: action.selectedHomepage,
-				sitegenSliceVersion: state.sitegenSliceVersion + 1,
-			};
-		case 'SET_HAS_GENERATED_SITE_PAGES':
-			return {
-				...state,
-				hasGeneratedSitePages: action.hasGeneratedSitePages,
-				sitegenSliceVersion: state.sitegenSliceVersion + 1,
-			};
-		case 'SET_RETRY_MODE':
-			return {
-				...state,
-				retryMode: action.retryMode,
-				sitegenSliceVersion: state.sitegenSliceVersion + 1,
-			};
-		case 'SET_SITEGEN_HAS_FAILED':
-			return {
-				...state,
-				sitegenHasFailed: action.sitegenHasFailed,
-				sitegenSliceVersion: state.sitegenSliceVersion + 1,
-			};
-		case 'SET_CANVAS_SIDEBAR_IS_OPEN':
-			return {
-				...state,
-				canvasSidebarIsOpen: action.canvasSidebarIsOpen,
+				siteGenId: action.siteGenId,
 				sitegenSliceVersion: state.sitegenSliceVersion + 1,
 			};
 	}
@@ -75,53 +47,24 @@ export const actions = {
 			siteGenSlice,
 		};
 	},
-	setHomepages: ( homepages ) => {
+	setSiteId: ( siteId ) => {
 		return {
-			type: 'SET_HOMEPAGES',
-			homepages,
+			type: 'SET_SITE_ID',
+			siteId,
 		};
 	},
-	setSelectedHomepage: ( selectedHomepage ) => {
+	setSiteGenId: ( siteGenId ) => {
 		return {
-			type: 'SET_SELECTED_HOMEPAGE',
-			selectedHomepage,
-		};
-	},
-	setHasGeneratedSitePages: ( hasGeneratedSitePages ) => {
-		return {
-			type: 'SET_HAS_GENERATED_SITE_PAGES',
-			hasGeneratedSitePages,
-		};
-	},
-	setRetryMode: ( retryMode ) => {
-		return {
-			type: 'SET_RETRY_MODE',
-			retryMode,
-		};
-	},
-	setSitegenHasFailed: ( sitegenHasFailed ) => {
-		return {
-			type: 'SET_SITEGEN_HAS_FAILED',
-			sitegenHasFailed,
-		};
-	},
-	setCanvasSidebarIsOpen: ( canvasSidebarIsOpen ) => {
-		return {
-			type: 'SET_CANVAS_SIDEBAR_IS_OPEN',
-			canvasSidebarIsOpen,
+			type: 'SET_SITE_GEN_ID',
+			siteGenId,
 		};
 	},
 };
 
 export const selectors = {
 	getSiteGenSlice: ( state ) => state.sitegen,
-	getHomepages: ( state ) => state.sitegen.homepages,
-	getSelectedHomepage: ( state ) => state.sitegen.selectedHomepage,
-	getHasGeneratedSitePages: ( state ) => state.sitegen.hasGeneratedSitePages,
-	getSelectedColorPalette: ( state ) => state.sitegen.homepages[ state.sitegen.selectedHomepage ]?.color?.palette,
-	getRetryMode: ( state ) => state.sitegen.retryMode,
-	getSitegenHasFailed: ( state ) => state.sitegen.sitegenHasFailed,
-	getCanvasSidebarIsOpen: ( state ) => state.sitegen.canvasSidebarIsOpen,
+	getSiteId: ( state ) => state.sitegen.siteId,
+	getSiteGenId: ( state ) => state.sitegen.siteGenId,
 	getSitegenSliceVersion: ( state ) => state.sitegen.sitegenSliceVersion,
 };
 

--- a/src/app/data/store/slices/sitegen.js
+++ b/src/app/data/store/slices/sitegen.js
@@ -5,6 +5,9 @@ import { updateOnboardingSiteGenSlice } from '@/utils/api';
 const DEFAULT_STATE = {
 	siteId: '',
 	siteGenId: '',
+	siteType: '',
+	enhancedPrompt: '',
+	discoveryData: {},
 	sitegenSliceVersion: 0,
 };
 
@@ -35,6 +38,24 @@ export function sitegen( state = DEFAULT_STATE, action ) {
 				siteGenId: action.siteGenId,
 				sitegenSliceVersion: state.sitegenSliceVersion + 1,
 			};
+		case 'SET_SITE_TYPE':
+			return {
+				...state,
+				siteType: action.siteType,
+				sitegenSliceVersion: state.sitegenSliceVersion + 1,
+			};
+		case 'SET_ENHANCED_PROMPT':
+			return {
+				...state,
+				enhancedPrompt: action.enhancedPrompt,
+				sitegenSliceVersion: state.sitegenSliceVersion + 1,
+			};
+		case 'SET_DISCOVERY_DATA':
+			return {
+				...state,
+				discoveryData: action.discoveryData,
+				sitegenSliceVersion: state.sitegenSliceVersion + 1,
+			};
 	}
 
 	return state;
@@ -47,24 +68,46 @@ export const actions = {
 			siteGenSlice,
 		};
 	},
-	setSiteId: ( siteId ) => {
-		return {
-			type: 'SET_SITE_ID',
-			siteId,
-		};
-	},
 	setSiteGenId: ( siteGenId ) => {
 		return {
 			type: 'SET_SITE_GEN_ID',
 			siteGenId,
 		};
 	},
+	setSiteId: ( siteId ) => {
+		return {
+			type: 'SET_SITE_ID',
+			siteId,
+		};
+	},
+	setSiteType: ( siteType ) => {
+		return {
+			type: 'SET_SITE_TYPE',
+			siteType,
+		};
+	},
+	setEnhancedPrompt: ( enhancedPrompt ) => {
+		return {
+			type: 'SET_ENHANCED_PROMPT',
+			enhancedPrompt,
+		};
+	},
+	setDiscoveryData: ( discoveryData ) => {
+		return {
+			type: 'SET_DISCOVERY_DATA',
+			discoveryData,
+		};
+	},
+
 };
 
 export const selectors = {
 	getSiteGenSlice: ( state ) => state.sitegen,
 	getSiteId: ( state ) => state.sitegen.siteId,
 	getSiteGenId: ( state ) => state.sitegen.siteGenId,
+	getDiscoveryData: ( state ) => state.sitegen.discoveryData,
+	getSiteType: ( state ) => state.sitegen.siteType,
+	getEnhancedPrompt: ( state ) => state.sitegen.enhancedPrompt,
 	getSitegenSliceVersion: ( state ) => state.sitegen.sitegenSliceVersion,
 };
 

--- a/src/app/hooks/publish/steps.js
+++ b/src/app/hooks/publish/steps.js
@@ -14,9 +14,9 @@ import {
 	installFonts,
 	enableJetpackModules,
 	completeOnboarding,
+	reportSiteGenPublished,
 } from '@/utils/api/onboarding';
 import { transformColorPalette } from '@/hooks/publish/tasks';
-
 /**
  * Each step function receives { generationData, discoveryData, ctx } and returns
  * a result string. ctx is a shared context object for passing data between steps
@@ -208,6 +208,7 @@ export async function runFinalize() {
 	if ( result?.error ) {
 		throw result.error;
 	}
+	reportSiteGenPublished();
 	return 'Site published';
 }
 

--- a/src/app/hooks/useChat.js
+++ b/src/app/hooks/useChat.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { useCallback, useState, useRef, useEffect } from '@wordpress/element';
+import { dispatch, select } from '@wordpress/data';
+import { nfdOnboardingStore } from '@/data/store';
 
 /**
  * Internal dependencies
@@ -26,7 +28,6 @@ import {
 	createInitialTasks,
 	createGenerationTasks,
 } from '@/hooks/chat/tasks';
-import { saveSitegenOptions } from '@/utils/api/onboarding';
 
 /**
  * useChat hook
@@ -107,7 +108,7 @@ const useChat = () => {
 
 				await streamSSE( response, ( { event, data } ) => {
 					if ( event === 'sitegen_started' ) {
-						saveSitegenOptions( { sitegen_id: data } );
+						dispatch( nfdOnboardingStore ).setSiteGenId( data );
 						return;
 					}
 
@@ -406,9 +407,15 @@ const useChat = () => {
 		setIsWaiting( true );
 		( async () => {
 			try {
-				const { site_id: siteId } = await handshake();
+				let siteId = select( nfdOnboardingStore ).getSiteId();
+				if ( ! siteId ) {
+					const response = await handshake();
+					siteId = response.site_id;
+					dispatch( nfdOnboardingStore ).setSiteId( siteId );
+				}
+
 				siteIdRef.current = siteId;
-				saveSitegenOptions( { sitegen_site_id: siteId } );
+
 				await runIntake();
 			} catch ( err ) {
 				// eslint-disable-next-line no-console

--- a/src/app/hooks/useChat.js
+++ b/src/app/hooks/useChat.js
@@ -27,6 +27,7 @@ import {
 	createInitialTasks,
 	createGenerationTasks,
 } from '@/hooks/chat/tasks';
+import { saveAiSitegenSiteId } from '@/utils/api/onboarding';
 
 /**
  * useChat hook
@@ -408,6 +409,7 @@ const useChat = () => {
 			try {
 				const { site_id: siteId } = await handshake();
 				siteIdRef.current = siteId;
+				saveAiSitegenSiteId( siteId );
 				await runIntake();
 			} catch ( err ) {
 				// eslint-disable-next-line no-console

--- a/src/app/hooks/useChat.js
+++ b/src/app/hooks/useChat.js
@@ -23,11 +23,10 @@ import {
 	MAX_RETRIES,
 	EVENT_TO_TASK_KEY,
 	GENERATION_ITEM_KEY_MAP,
-	GENERATION_TASK_KEYS,
 	createInitialTasks,
 	createGenerationTasks,
 } from '@/hooks/chat/tasks';
-import { saveAiSitegenSiteId } from '@/utils/api/onboarding';
+import { saveSitegenOptions } from '@/utils/api/onboarding';
 
 /**
  * useChat hook
@@ -107,6 +106,11 @@ const useChat = () => {
 				);
 
 				await streamSSE( response, ( { event, data } ) => {
+					if ( event === 'sitegen_started' ) {
+						saveSitegenOptions( { sitegen_id: data } );
+						return;
+					}
+
 					// --- Discovery phase events ---
 					if ( event === 'sitegen_discovery_started' ) {
 						startAllTasks( discoveryMsgId );
@@ -117,6 +121,7 @@ const useChat = () => {
 					if ( discoveryTaskKey ) {
 						if (
 							discoveryTaskKey === 'brand_identity' ||
+							discoveryTaskKey === 'sitemap' ||
 							discoveryTaskKey === 'site_type'
 						) {
 							try {
@@ -167,12 +172,6 @@ const useChat = () => {
 						if ( taskKey ) {
 							completeTask( generationMsgId, taskKey, 'Done' );
 						}
-						return;
-					}
-
-					const sitekitStepMatch = event.match( /^sitegen_sitekit_step_(.+)$/ );
-					if ( sitekitStepMatch && generationMsgId && GENERATION_TASK_KEYS.has( sitekitStepMatch[ 1 ] ) ) {
-						completeTask( generationMsgId, sitekitStepMatch[ 1 ], 'Done' );
 						return;
 					}
 
@@ -409,7 +408,7 @@ const useChat = () => {
 			try {
 				const { site_id: siteId } = await handshake();
 				siteIdRef.current = siteId;
-				saveAiSitegenSiteId( siteId );
+				saveSitegenOptions( { sitegen_site_id: siteId } );
 				await runIntake();
 			} catch ( err ) {
 				// eslint-disable-next-line no-console

--- a/src/app/hooks/useChat.js
+++ b/src/app/hooks/useChat.js
@@ -112,6 +112,16 @@ const useChat = () => {
 						return;
 					}
 
+					if ( event === 'sitegen_discovery_prompt_enhance_completed' ) {
+						dispatch( nfdOnboardingStore ).setEnhancedPrompt( data );
+						return;
+					}
+
+					if ( event === 'sitegen_discovery_site_type_completed' ) {
+						dispatch( nfdOnboardingStore ).setSiteType( data );
+						return;
+					}
+
 					// --- Discovery phase events ---
 					if ( event === 'sitegen_discovery_started' ) {
 						startAllTasks( discoveryMsgId );
@@ -142,6 +152,7 @@ const useChat = () => {
 
 					if ( event === 'sitegen_discovery_completed' ) {
 						finishAllTasks( discoveryMsgId );
+						dispatch( nfdOnboardingStore ).setDiscoveryData( data );
 
 						addMessage( {
 							role: 'assistant',

--- a/src/app/utils/api/ai-platform.js
+++ b/src/app/utils/api/ai-platform.js
@@ -1,8 +1,10 @@
+import apiFetch from '@wordpress/api-fetch';
+
 /**
  * Internal dependencies
  */
-import { aiPlatformBase, wpSiteUrl } from '@/data/constants';
-
+import { aiPlatformBase } from '@/data/constants';
+import { onboardingRestURL } from '@/utils/api/onboarding';
 const SITEGEN_URL = `${ aiPlatformBase }/api/v1/sitegen`;
 
 const JSON_HEADERS = {
@@ -11,23 +13,22 @@ const JSON_HEADERS = {
 };
 
 /**
- * Perform a handshake with the AI platform to obtain a site_id.
+ * Perform an authenticated handshake with the AI platform to obtain a site_id.
  *
  * @param {string} domain The site domain.
  * @return {Promise<Object>} Response containing site_id.
  */
-export async function handshake( domain = wpSiteUrl ) {
-	const response = await fetch( `${ SITEGEN_URL }/handshake`, {
+export async function handshake() {
+	const response = await apiFetch( {
+		url: onboardingRestURL( 'sitegen/handshake' ),
 		method: 'POST',
-		headers: JSON_HEADERS,
-		body: JSON.stringify( { domain } ),
 	} );
 
-	if ( ! response.ok ) {
-		throw new Error( `Handshake failed: ${ response.status }` );
+	if ( ! response?.site_id ) {
+		throw new Error( `Handshake failed: ${ response?.error ?? 'Unknown error' }` );
 	}
 
-	return response.json();
+	return response;
 }
 
 /**

--- a/src/app/utils/api/onboarding.js
+++ b/src/app/utils/api/onboarding.js
@@ -417,22 +417,6 @@ export const importBlueprint = async ( selectedBlueprintSlug ) => {
 };
 
 /**
- * Save the sitegen options.
- *
- * @param {Object} options The options to save.
- * @return {Promise<Object>} response
- */
-export const saveSitegenOptions = async ( options ) => {
-	return await resolve(
-		apiFetch( {
-			url: onboardingRestURL( 'sitegen/options' ),
-			method: 'POST',
-			data: { options },
-		} ).then()
-	);
-};
-
-/**
  * Report the published site.
  *
  * @return {Promise<Object>} response

--- a/src/app/utils/api/onboarding.js
+++ b/src/app/utils/api/onboarding.js
@@ -416,21 +416,20 @@ export const importBlueprint = async ( selectedBlueprintSlug ) => {
 	);
 };
 
-
 /**
- * Persist the AI sitegen site ID.
+ * Save the sitegen options.
  *
- * @param {string} siteId The site ID.
+ * @param {Object} options The options to save.
  * @return {Promise<Object>} response
  */
-export const saveAiSitegenSiteId = async ( siteId ) => {
-    return await resolve(
-        apiFetch( {
-            url: onboardingRestURL( 'sitegen/ai-site-id' ),
-            method: 'POST',
-            data: { site_id: siteId },
-        } ).then()
-    );
+export const saveSitegenOptions = async ( options ) => {
+	return await resolve(
+		apiFetch( {
+			url: onboardingRestURL( 'sitegen/options' ),
+			method: 'POST',
+			data: { options },
+		} ).then()
+	);
 };
 
 /**
@@ -439,10 +438,10 @@ export const saveAiSitegenSiteId = async ( siteId ) => {
  * @return {Promise<Object>} response
  */
 export const reportSiteGenPublished = async () => {
-    return await resolve(
-        apiFetch( {
-            url: onboardingRestURL( 'sitegen/report-published' ),
-            method: 'POST',
-        } ).then()
-    );
+	return await resolve(
+		apiFetch( {
+			url: onboardingRestURL( 'sitegen/report-published' ),
+			method: 'POST',
+		} ).then()
+	);
 };

--- a/src/app/utils/api/onboarding.js
+++ b/src/app/utils/api/onboarding.js
@@ -415,3 +415,34 @@ export const importBlueprint = async ( selectedBlueprintSlug ) => {
 		} ).then()
 	);
 };
+
+
+/**
+ * Persist the AI sitegen site ID.
+ *
+ * @param {string} siteId The site ID.
+ * @return {Promise<Object>} response
+ */
+export const saveAiSitegenSiteId = async ( siteId ) => {
+    return await resolve(
+        apiFetch( {
+            url: onboardingRestURL( 'sitegen/ai-site-id' ),
+            method: 'POST',
+            data: { site_id: siteId },
+        } ).then()
+    );
+};
+
+/**
+ * Report the published site.
+ *
+ * @return {Promise<Object>} response
+ */
+export const reportSiteGenPublished = async () => {
+    return await resolve(
+        apiFetch( {
+            url: onboardingRestURL( 'sitegen/report-published' ),
+            method: 'POST',
+        } ).then()
+    );
+};

--- a/src/onboarding.js
+++ b/src/onboarding.js
@@ -6,10 +6,11 @@ import { dispatch } from '@wordpress/data';
 import { onboardingRestURL, startOnboarding } from '@/utils/api';
 import { CATEGORY } from '@/utils/analytics/hiive/constants';
 import { POSTHOG_PUBLIC } from '@/data/constants';
-import { nfdOnboardingStore } from '@/data/store';
+import { nfdOnboardingStore, initializeStoreDbSyncServices } from '@/data/store';
 import { isCypress } from '@/utils/helpers';
 import './webpack-public-path';
 import { PostHogProvider } from 'posthog-js/react';
+
 import App from '@';
 
 // Check if the runtime data object is mounted.
@@ -82,10 +83,10 @@ if ( runtimeDataObjectIsMounted() ) {
 		initializeAnalytics();
 		startOnboarding();
 
-		// Hydrate the Redux store with server-side runtime data.
-		dispatch( nfdOnboardingStore ).setRuntimeSlice(
-			window.nfdOnboarding.runtime
-		);
+		// Hydrate the Redux store with server-side runtime and sitegen data.
+		dispatch( nfdOnboardingStore ).setRuntimeSlice( window.nfdOnboarding.runtime );
+		dispatch( nfdOnboardingStore ).setSiteGenSlice( window.nfdOnboarding.sitegen );
+		initializeStoreDbSyncServices();
 
 		const NFD_ONBOARDING_ELEMENT_ID = 'nfd-onboarding';
 		const appTarget = document.getElementById( NFD_ONBOARDING_ELEMENT_ID );


### PR DESCRIPTION
## Proposed changes

https://newfold.atlassian.net/browse/PRESS0-4233
https://newfold.atlassian.net/browse/PRESS0-4218

Adds **SiteGenServiceRequest** service class to handle **authenticated**, async HTTP requests to the AI Platform.

Adds **SiteGenAiController** with two REST endpoints:

`POST /sitegen/handshake` — performs a handshake with the AI Platform, returning the site_id for the current site
`POST /sitegen/report-published` — reads the stored `sitegen_current_id` and fires a fire-and-forget request to the AI Platform (sitegen/select) to report the published site


Registers all **SiteGen Options** keys in Options.php:

`sitegen_site_id` — the site identifier returned by the AI Platform on handshake
`sitegen_current_id` — the most recent SiteGen generation ID
`sitegen_previous_ids` — array of all previous SiteGen IDs (accumulated on each new generation)
`sitegen_site_type` — the site type determined during discovery
`sitegen_enhanced_prompt` — the enhanced prompt produced by the AI
`sitegen_discovery_data` — full discovery results, stored for potential post-onboarding use

**Each field of the sitegen Redux slice is now persisted in its own dedicated WordPress option** instead of a single serialised blob. 
`ReduxStateController::update_sitegen_slice_state()` writes each field individually; `get_sitegen_slice_state()` reconstructs the slice from those options. 
`ReduxStateService::get('sitegen')` uses the same logic (via get_state_sitegen()) so the bootstrap data inlined on page load is also sourced from the individual options.

When a new `sitegen_current_id` arrives and differs from the stored value, the old ID is appended to `sitegen_previous_ids` before the current ID is updated.

Calls `reportSiteGenPublished()` at the end of the publish pipeline, after onboarding completes and the site is live.

**Note**: Two options intentionally survive an onboarding restart:
`sitegen_site_id` — the site identity does not change between runs; the handshake is not repeated
`sitegen_previous_ids` — preserves the history of all past generation IDs across restarts

**Important**: `sitegen_site_id` is tied to the domain registered with the AI Platform. When switching environments (e.g. local → staging → production) the stored `site_id` will not be recognised by the Platform. In that case the option `nfd_module_onboarding_sitegen_site_id` should be removed manually from the database before running the onboarding again.


#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->