### PR TITLE
Features/blu flow

### DIFF
--- a/includes/Data/Options.php
+++ b/includes/Data/Options.php
@@ -88,7 +88,7 @@ final class Options {
 	 * @var string
 	 */
 	protected static $origin_options = array(
-		'origin_prompt' => 'prompt',
+		'origin_prompt'           => 'prompt',
 		'origin_prompt_completed' => 'prompt_completed',
 	);
 
@@ -129,7 +129,7 @@ final class Options {
 	 *
 	 * @return array
 	 */
-	public static function get_all_options() {
+	public static function get_all_options(): array {
 		return self::$options;
 	}
 
@@ -138,7 +138,7 @@ final class Options {
 	 *
 	 * @return array
 	 */
-	public static function get_initialization_options() {
+	public static function get_initialization_options(): array {
 		return self::$initialization_options;
 	}
 
@@ -147,7 +147,7 @@ final class Options {
 	 *
 	 * @return array
 	 */
-	public static function get_wc_settings_options() {
+	public static function get_wc_settings_options(): array {
 		return array(
 			'wc_currency'          => array(
 				'show_in_rest' => true,
@@ -206,10 +206,10 @@ final class Options {
 	/**
 	 * Get the prompt origin option name.
 	 *
+	 * @param string $option_key Option key.
 	 * @return string The option name for the prompt origin.
 	 */
-	public static function get_origin_option_name( $option_key ) {
-		return isset( self::$origin_options[ $option_key ] ) ? self::$prefix_origin . self::$origin_options[ $option_key ] : false;	
+	public static function get_origin_option_name( $option_key ): string {
+		return isset( self::$origin_options[ $option_key ] ) ? self::$prefix_origin . self::$origin_options[ $option_key ] : false;
 	}
-
 }

--- a/includes/Data/Options.php
+++ b/includes/Data/Options.php
@@ -13,6 +13,13 @@ final class Options {
 	protected static $prefix = 'nfd_module_onboarding_';
 
 	/**
+	 * Prefix for options in the module.
+	 *
+	 * @var string
+	 */
+	protected static $prefix_origin = 'nfd_origin_';
+
+	/**
 	 * List of all the options.
 	 *
 	 * @var array
@@ -73,6 +80,16 @@ final class Options {
 		'sitegen_site_type'             => 'sitegen_site_type',
 		'sitegen_enhanced_prompt'       => 'sitegen_enhanced_prompt',
 		'sitegen_discovery_data'        => 'sitegen_discovery_data',
+	);
+
+	/**
+	 * The option name for the prompt origin.
+	 *
+	 * @var string
+	 */
+	protected static $origin_options = array(
+		'origin_prompt' => 'prompt',
+		'origin_prompt_completed' => 'prompt_completed',
 	);
 
 	/**
@@ -184,4 +201,15 @@ final class Options {
 			),
 		);
 	}
+
+
+	/**
+	 * Get the prompt origin option name.
+	 *
+	 * @return string The option name for the prompt origin.
+	 */
+	public static function get_origin_option_name( $option_key ) {
+		return isset( self::$origin_options[ $option_key ] ) ? self::$prefix_origin . self::$origin_options[ $option_key ] : false;	
+	}
+
 }

--- a/includes/RestApi/SiteGenAiController.php
+++ b/includes/RestApi/SiteGenAiController.php
@@ -10,6 +10,15 @@ use NewfoldLabs\WP\Module\Onboarding\Data\Options;
  * Class SiteGenAiController
  */
 class SiteGenAiController {
+
+	/**
+	 * Full REST path for handshake (for WP_REST_Request / rest_do_request).
+	 * Must match namespace + rest_base + '/handshake' below.
+	 *
+	 * @var string
+	 */
+	public const REST_ROUTE_HANDSHAKE = '/newfold-onboarding/v1/sitegen/handshake';
+
 	/**
 	 * The namespace of this controller's route.
 	 *

--- a/includes/Services/ReduxStateService.php
+++ b/includes/Services/ReduxStateService.php
@@ -8,6 +8,7 @@
 namespace NewfoldLabs\WP\Module\Onboarding\Services;
 
 use NewfoldLabs\WP\Module\Onboarding\Data\Options;
+use NewfoldLabs\WP\Module\Onboarding\RestApi\SiteGenAiController;
 
 /**
  * Redux State Service Class
@@ -70,6 +71,40 @@ class ReduxStateService {
 			'discoveryData'       => \get_option( Options::get_option_name( 'sitegen_discovery_data' ), array() ),
 			'sitegenSliceVersion' => 0,
 		);
+	}
+
+
+
+	/**
+	 * Ensure `sitegen_site_id` is stored: if missing, handshake and persist (same option as sitegen slice updates).
+	 *
+	 * @return string Existing or new site_id, or empty string if missing and handshake failed.
+	 */
+	public static function ensure_sitegen_site_id(): string {
+		$option_key = Options::get_option_name( 'sitegen_site_id' );
+		$existing   = \get_option( $option_key, '' );
+		if ( ! empty( $existing ) ) {
+			return $existing;
+		}
+
+		$rest_request = new \WP_REST_Request(
+			\WP_REST_Server::CREATABLE,
+			SiteGenAiController::REST_ROUTE_HANDSHAKE
+		);
+		$rest_response = \rest_do_request( $rest_request );
+
+		if ( $rest_response->is_error() || $rest_response->get_status() >= 400 ) {
+			return '';
+		}
+
+		$data = $rest_response->get_data();
+		if ( empty( $data['site_id'] ) ) {
+			return '';
+		}
+
+		\update_option( $option_key, $data['site_id'] );
+
+		return $data['site_id'];
 	}
 
 	/**

--- a/includes/Services/ReduxStateService.php
+++ b/includes/Services/ReduxStateService.php
@@ -87,7 +87,7 @@ class ReduxStateService {
 			return $existing;
 		}
 
-		$rest_request = new \WP_REST_Request(
+		$rest_request  = new \WP_REST_Request(
 			\WP_REST_Server::CREATABLE,
 			SiteGenAiController::REST_ROUTE_HANDSHAKE
 		);

--- a/includes/Services/ResetService.php
+++ b/includes/Services/ResetService.php
@@ -126,10 +126,10 @@ class ResetService {
 	 */
 	private static function reset_prompt_origin(): void {
 		$origin_prompt = get_option( Options::get_origin_option_name( 'origin_prompt' ) );
-		if( !empty( $origin_prompt ) ) {
+		if ( ! empty( $origin_prompt ) ) {
 			update_option( Options::get_origin_option_name( 'origin_prompt_completed' ), $origin_prompt );
 		}
-		
+
 		delete_option( Options::get_origin_option_name( 'origin_prompt' ) );
 	}
 }

--- a/includes/Services/ResetService.php
+++ b/includes/Services/ResetService.php
@@ -2,6 +2,8 @@
 
 namespace NewfoldLabs\WP\Module\Onboarding\Services;
 
+use NewfoldLabs\WP\Module\Onboarding\Data\Options;
+
 /**
  * Reset Services
  *
@@ -19,6 +21,7 @@ class ResetService {
 		self::reset_site_identity();
 		self::reset_onboarding_options();
 		self::unschedule_cron_jobs();
+		self::reset_prompt_origin();
 	}
 
 	/**
@@ -114,5 +117,19 @@ class ResetService {
 	private static function unschedule_cron_jobs(): void {
 		wp_unschedule_hook( MediaService::CRON_HOOK );
 		wp_unschedule_hook( SiteGenImageService::CRON_HOOK );
+	}
+
+	/**
+	 * Reset the prompt origin and save it  in the prompt_completed option
+	 *
+	 * @return void
+	 */
+	private static function reset_prompt_origin(): void {
+		$origin_prompt = get_option( Options::get_origin_option_name( 'origin_prompt' ) );
+		if( !empty( $origin_prompt ) ) {
+			update_option( Options::get_origin_option_name( 'origin_prompt_completed' ), $origin_prompt );
+		}
+		
+		delete_option( Options::get_origin_option_name( 'origin_prompt' ) );
 	}
 }

--- a/includes/WP_Admin.php
+++ b/includes/WP_Admin.php
@@ -7,6 +7,7 @@ use NewfoldLabs\WP\Module\Onboarding\Services\ThemeService;
 use NewfoldLabs\WP\Module\Onboarding\Services\I18nService;
 use NewfoldLabs\WP\Module\Onboarding\Services\ReduxStateService;
 use NewfoldLabs\WP\Module\Onboarding\Data\Runtime;
+use NewfoldLabs\WP\Module\Onboarding\Data\Options;
 use NewfoldLabs\WP\Module\Patterns\SiteClassification as PatternsSiteClassification;
 
 /**
@@ -174,6 +175,7 @@ final class WP_Admin {
 			$nfd_onboarding_data = array(
 				'runtime' => Runtime::get_data(),
 				'sitegen' => ReduxStateService::get( 'sitegen' ),
+				'origin' => array( 'prompt' => get_option( Options::get_origin_option_name( 'origin_prompt' ) )),
 			);
 			\wp_add_inline_script(
 				self::$slug,
@@ -262,6 +264,9 @@ final class WP_Admin {
 		if ( ! $default_theme_installation_result ) {
 			self::exit_to_dashboard();
 		}
+
+		// Ensure sitegen site id is set
+		ReduxStateService::ensure_sitegen_site_id();
 
 		self::register_assets();
 	}

--- a/includes/WP_Admin.php
+++ b/includes/WP_Admin.php
@@ -175,7 +175,7 @@ final class WP_Admin {
 			$nfd_onboarding_data = array(
 				'runtime' => Runtime::get_data(),
 				'sitegen' => ReduxStateService::get( 'sitegen' ),
-				'origin' => array( 'prompt' => get_option( Options::get_origin_option_name( 'origin_prompt' ) )),
+				'origin'  => array( 'prompt' => get_option( Options::get_origin_option_name( 'origin_prompt' ) ) ),
 			);
 			\wp_add_inline_script(
 				self::$slug,

--- a/src/app/hooks/useChat.js
+++ b/src/app/hooks/useChat.js
@@ -73,7 +73,6 @@ const useChat = () => {
 			abortRef.current?.abort();
 		};
 	}, [] );
-	 
 
 	const handleDiscoveryEvent = useCallback(
 		( msgId, event, data ) => {
@@ -278,7 +277,7 @@ const useChat = () => {
 		},
 		[ setMessages, startAllTasks, handleDiscoveryEvent, finishAllTasks, addMessage, completeTask, getNextId ]
 	);
-	
+
 	/**
 	 * Auto-start: when window.nfdOnboarding.origin.prompt is set, skip PromptView
 	 * and the intake conversation and jump straight to generation.
@@ -313,7 +312,6 @@ const useChat = () => {
 
 		runStream( discoveryId );
 	}, [ addMessage, getNextId, runStream ] );
-
 
 	useEffect( () => {
 		handleOriginStart();

--- a/src/app/hooks/useChat.js
+++ b/src/app/hooks/useChat.js
@@ -39,7 +39,9 @@ import {
  */
 const useChat = () => {
 	const [ prompt, setPrompt ] = useState( '' );
-	const [ mode, setMode ] = useState( 'prompt' );
+	const [ mode, setMode ] = useState( () =>
+		window.nfdOnboarding?.origin?.prompt ? 'chat' : 'prompt'
+	);
 	const [ chatInput, setChatInput ] = useState( '' );
 	const [ isWaiting, setIsWaiting ] = useState( false );
 	const [ inputEnabled, setInputEnabled ] = useState( false );
@@ -71,6 +73,7 @@ const useChat = () => {
 			abortRef.current?.abort();
 		};
 	}, [] );
+	 
 
 	const handleDiscoveryEvent = useCallback(
 		( msgId, event, data ) => {
@@ -275,6 +278,46 @@ const useChat = () => {
 		},
 		[ setMessages, startAllTasks, handleDiscoveryEvent, finishAllTasks, addMessage, completeTask, getNextId ]
 	);
+	
+	/**
+	 * Auto-start: when window.nfdOnboarding.origin.prompt is set, skip PromptView
+	 * and the intake conversation and jump straight to generation.
+	 * The handshake is handled PHP-side so siteId is already in the store.
+	 */
+	const handleOriginStart = useCallback( () => {
+		const originPrompt = window.nfdOnboarding?.origin?.prompt;
+		if ( ! originPrompt ) {
+			return;
+		}
+
+		const userPrompt = originPrompt.trim();
+		originalPromptRef.current = userPrompt;
+		conversationRef.current = [ { role: 'user', content: userPrompt } ];
+		siteIdRef.current = select( nfdOnboardingStore ).getSiteId();
+
+		addMessage( { role: 'user', content: userPrompt } );
+
+		startTimeRef.current = Date.now();
+		sendOnboardingEvent( new OnboardingEvent( ACTION_ONBOARDING_STARTED ) );
+		sendOnboardingEvent( new OnboardingEvent( ACTION_INTAKE_PROMPT_SET, userPrompt ) );
+
+		setIsWaiting( true );
+
+		const discoveryId = getNextId();
+		addMessage( {
+			id: discoveryId,
+			role: 'discovery',
+			title: 'Site discovery',
+			tasks: createInitialTasks(),
+		} );
+
+		runStream( discoveryId );
+	}, [ addMessage, getNextId, runStream ] );
+
+
+	useEffect( () => {
+		handleOriginStart();
+	}, [ handleOriginStart ] );
 
 	/**
 	 * Retry the generation stream with the same site_id and prompt.


### PR DESCRIPTION
## Proposed changes

https://newfold.atlassian.net/browse/PRESS0-4249

**Handshake**
The handshake is now performed server-side: `siteId` is resolved in PHP and passed to the frontend as part of window.nfdOnboarding.sitegen, which is hydrated into the Redux store on page load. The client-side handshake call (handshake()) is no longer needed in the origin flow.

**Blu prompt: nfd_origin_prompt**
`nfd_origin_prompt `is retrieved server-side and passed to the frontend via window.nfdOnboarding.origin.prompt 

If the prompt is set is triggered `handleOriginStart` — reads the origin prompt, sets the required refs, fires the standard analytics events (ACTION_ONBOARDING_STARTED, ACTION_INTAKE_PROMPT_SET) and calls `runStream` directly, skipping intake entirely

`handleOriginStart` is called once on mount via useEffect

**Updated ResetService**
On reset/complete, `nfd_origin_prompt` is removed and its value is saved into `nfd_origin_prompt_completed` — so the original prompt is preserved for reference without being re-triggered on subsequent page loads.


#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->