### PR TITLE
feat: dev-only sitekit override for onboarding

### DIFF
--- a/src/app/hooks/useChat.js
+++ b/src/app/hooks/useChat.js
@@ -47,6 +47,8 @@ const useChat = () => {
 	const [ chatInput, setChatInput ] = useState( '' );
 	const [ isWaiting, setIsWaiting ] = useState( false );
 	const [ inputEnabled, setInputEnabled ] = useState( false );
+	const [ devSitekitSlug, setDevSitekitSlugState ] = useState( '' );
+	const devSitekitSlugRef = useRef( '' );
 	const siteIdRef = useRef( null );
 	const abortRef = useRef( null );
 	const originalPromptRef = useRef( '' );
@@ -75,6 +77,11 @@ const useChat = () => {
 		finishAllTasks,
 		resetMessages,
 	} = useMessages();
+
+	const setDevSitekitSlug = useCallback( ( slug ) => {
+		devSitekitSlugRef.current = slug;
+		setDevSitekitSlugState( slug );
+	}, [] );
 
 	// Abort any in-flight stream on unmount.
 	useEffect( () => {
@@ -110,11 +117,16 @@ const useChat = () => {
 
 			try {
 				const validConversation = conversationRef.current.filter( ( msg ) => msg.content );
+				const devSitekit =
+					process.env.NODE_ENV === 'development' && devSitekitSlugRef.current
+						? devSitekitSlugRef.current.trim() || null
+						: null;
 				const response = await startGeneration(
 					siteIdRef.current,
 					originalPromptRef.current,
 					controller.signal,
-					validConversation.length ? validConversation : null
+					validConversation.length ? validConversation : null,
+					devSitekit
 				);
 
 				await streamSSE( response, ( { event, data } ) => {
@@ -555,6 +567,8 @@ const useChat = () => {
 		isWaiting,
 		inputEnabled,
 		showMigration,
+		devSitekitSlug,
+		setDevSitekitSlug,
 		handlePromptSubmit,
 		handleChatSubmit,
 		handleRetry,

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -38,6 +38,8 @@ const App = () => {
 		isWaiting,
 		inputEnabled,
 		showMigration,
+		devSitekitSlug,
+		setDevSitekitSlug,
 		handlePromptSubmit,
 		handleChatSubmit,
 		handleRetry,
@@ -72,6 +74,8 @@ const App = () => {
 							onSubmit={ handlePromptSubmit }
 							onMigrate={ handleMigrate }
 							showMigration={ showMigration }
+							devSitekitSlug={ devSitekitSlug }
+							setDevSitekitSlug={ setDevSitekitSlug }
 						/>
 					) }
 					{ mode === 'chat' && (

--- a/src/app/utils/api/ai-platform.js
+++ b/src/app/utils/api/ai-platform.js
@@ -81,9 +81,10 @@ export async function intake( siteId, prompt, conversation = null, signal ) {
  * @param {string}      prompt       The user's site prompt.
  * @param {AbortSignal} signal       AbortController signal for cancellation.
  * @param {Array|null}  conversation Optional conversation history [{role, content}].
+ * @param {string|null} sitekit      Optional sitekit slug to force-select (dev only).
  * @return {Promise<Response>} Raw fetch Response with readable SSE body.
  */
-export async function startGeneration( siteId, prompt, signal, conversation = null ) {
+export async function startGeneration( siteId, prompt, signal, conversation = null, sitekit = null ) {
 	const body = {
 		site_id: siteId,
 		site_prompt: prompt,
@@ -91,6 +92,10 @@ export async function startGeneration( siteId, prompt, signal, conversation = nu
 
 	if ( conversation && conversation.length ) {
 		body.conversation = conversation;
+	}
+
+	if ( sitekit ) {
+		body.sitekit = sitekit;
 	}
 
 	const response = await fetch( `${ SITEGEN_URL }/generate`, {

--- a/src/app/views/PromptView.js
+++ b/src/app/views/PromptView.js
@@ -18,7 +18,15 @@ import PromptCard from '@/components/prompt/PromptCard.jsx';
 import { nfdOnboardingStore } from '@/data/store';
 import getGreeting from '@/utils/helpers/getGreeting';
 
-const PromptView = ( { prompt, setPrompt, onSubmit, onMigrate, showMigration = false } ) => {
+const PromptView = ( {
+	prompt,
+	setPrompt,
+	onSubmit,
+	onMigrate,
+	showMigration = false,
+	devSitekitSlug = '',
+	setDevSitekitSlug,
+} ) => {
 	const displayName = useSelect(
 		( select ) => select( nfdOnboardingStore ).getCurrentUserDisplayName(),
 		[]
@@ -49,6 +57,24 @@ const PromptView = ( { prompt, setPrompt, onSubmit, onMigrate, showMigration = f
 						onSubmit={ onSubmit }
 						isSubmitting={ false }
 					/>
+					{ process.env.NODE_ENV === 'development' && (
+						<div className="nfd-mt-3 nfd-flex nfd-items-center nfd-gap-2 nfd-px-1">
+							<label
+								htmlFor="nfd-dev-sitekit-slug"
+								className="nfd-text-xs nfd-font-medium nfd-text-[rgb(95,99,104)] nfd-whitespace-nowrap"
+							>
+								{ __( 'Dev — sitekit slug:', 'wp-module-onboarding' ) }
+							</label>
+							<input
+								id="nfd-dev-sitekit-slug"
+								type="text"
+								value={ devSitekitSlug }
+								onChange={ ( e ) => setDevSitekitSlug( e.target.value ) }
+								placeholder={ __( 'leave empty for AI selection', 'wp-module-onboarding' ) }
+								className="nfd-flex-1 nfd-text-xs nfd-border nfd-border-solid nfd-border-[rgb(218,220,224)] nfd-rounded nfd-px-2 nfd-py-1 nfd-bg-transparent nfd-text-[rgb(31,31,31)] focus:nfd-outline-none focus:nfd-border-[rgb(23,108,223)]"
+							/>
+						</div>
+					) }
 				</div>
 
 				{ showMigration && (


### PR DESCRIPTION
## Summary

- Adds a sitekit slug input below the prompt card, visible only when `NODE_ENV === 'development'`
- When a slug is provided, it is forwarded as `sitekit` in the AI platform `/sitegen/generate` request body, bypassing the AI's automatic sitekit selection
- Both the UI block and the forwarding logic are gated by `process.env.NODE_ENV === 'development'` — Webpack eliminates them entirely from production builds; no runtime cost in prod
- Slug is trimmed at the consumption point (`.trim() || null`) so accidental whitespace doesn't silently send a non-matching slug to the API

## Files changed

- `src/app/utils/api/ai-platform.js` — `startGeneration` accepts optional `sitekit` param
- `src/app/hooks/useChat.js` — dev sitekit state + ref, passed to `startGeneration` in dev mode
- `src/app/index.js` — props wired to `PromptView`
- `src/app/views/PromptView.js` — dev-only input rendered below `PromptCard`

## Test plan

- [ ] In dev (`npm run start`), verify the sitekit slug input appears below the prompt card
- [ ] Enter a valid sitekit slug, submit a prompt, confirm the AI platform receives the `sitekit` field in the generate request
- [ ] Leave the field empty and confirm normal AI sitekit selection still works
- [ ] Run a production build (`npm run build`) and confirm the input does not appear and no `sitekit` key is sent