### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required by reusable-translations jobs that push the auto-translate branch and commits.
+      pull-requests: write # Required for gh pr list, update-branch, and create in reusable-translations workflow.
     with:
       text_domain: 'wp-module-onboarding'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required by reusable-translations jobs that push the auto-translate branch and commits.
       pull-requests: write # Required for gh pr list, update-branch, and create in reusable-translations workflow.
+    timeout-minutes: 120
     with:
       text_domain: 'wp-module-onboarding'
     secrets:

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -21,6 +21,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # No checkout or GitHub API calls; only derives the branch name from the event.
+    timeout-minutes: 30
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -35,6 +36,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
     permissions:
       contents: read # Required for reusable module-plugin-test workflow to check out the plugin and module repositories.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -47,6 +49,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
     permissions:
       contents: read # Required for reusable module-plugin-test workflow to check out the plugin and module repositories.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -59,6 +62,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
     permissions:
       contents: read # Required for reusable module-plugin-test workflow to check out the plugin and module repositories.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -12,10 +12,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {} # No checkout or GitHub API calls; only derives the branch name from the event.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -28,6 +33,8 @@ jobs:
     name: Bluehost Build and Test
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    permissions:
+      contents: read # Required for reusable module-plugin-test workflow to check out the plugin and module repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -38,6 +45,8 @@ jobs:
     name: HostGator Build and Test
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    permissions:
+      contents: read # Required for reusable module-plugin-test workflow to check out the plugin and module repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -48,6 +57,8 @@ jobs:
     name: Crazy Domains Build and Test
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    permissions:
+      contents: read # Required for reusable module-plugin-test workflow to check out the plugin and module repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -24,6 +24,7 @@ jobs:
         permissions:
           contents: write      # Required for git-auto-commit-action to push coverage output to gh-pages with github.token.
           pull-requests: write # Required for mshick/add-pr-comment to post coverage comments on pull requests.
+        timeout-minutes: 90
 
         services:
             mysql:

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,10 +13,17 @@ on:
             - trunk
     workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
     codecoverage:
         runs-on: ubuntu-latest
+        permissions:
+          contents: write      # Required for git-auto-commit-action to push coverage output to gh-pages with github.token.
+          pull-requests: write # Required for mshick/add-pr-comment to post coverage comments on pull requests.
 
         services:
             mysql:

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,15 +8,18 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
+    permissions:
+      contents: read # Required for the reusable Crowdin download workflow to clone the caller repository; Crowdin uses NEWFOLD_ACCESS_TOKEN for PRs.
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:
       CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      NEWFOLD_ACCESS_TOKEN: ${{ secrets.NEWFOLD_ACCESS_TOKEN }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -17,6 +17,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
       contents: read # Required for the reusable Crowdin download workflow to clone the caller repository; Crowdin uses NEWFOLD_ACCESS_TOKEN for PRs.
+    timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,9 +3,15 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
+    permissions:
+      contents: read # Required for the reusable Crowdin upload workflow to clone the caller repository (matches newfold-labs/workflows i18n-crowdin-upload).
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -12,6 +12,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
       contents: read # Required for the reusable Crowdin upload workflow to clone the caller repository (matches newfold-labs/workflows i18n-crowdin-upload).
+    timeout-minutes: 30
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/lint-check-php.yml
+++ b/.github/workflows/lint-check-php.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read         # Required to clone the repository for actions/checkout.
       pull-requests: read    # Required for get-diff-action to resolve the merge base on pull_request events.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-check-php.yml
+++ b/.github/workflows/lint-check-php.yml
@@ -15,10 +15,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read         # Required to clone the repository for actions/checkout.
+      pull-requests: read    # Required for get-diff-action to resolve the merge base on pull_request events.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-check-spa.yml
+++ b/.github/workflows/lint-check-spa.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read         # Required to clone the repository for actions/checkout.
       pull-requests: read    # Required for get-diff-action to resolve the merge base on pull_request events.
+    timeout-minutes: 30
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/lint-check-spa.yml
+++ b/.github/workflows/lint-check-spa.yml
@@ -15,10 +15,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   lint-check-spa:
     name: Run Lint Checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read         # Required to clone the repository for actions/checkout.
+      pull-requests: read    # Required for get-diff-action to resolve the merge base on pull_request events.
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push the release branch and version-bump commits with GITHUB_TOKEN.
       pull-requests: write # Required for the reusable workflow to create the draft release pull request with gh.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'trunk'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,10 +21,10 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to push the release branch and version-bump commits with GITHUB_TOKEN.
+      pull-requests: write # Required for the reusable workflow to create the draft release pull request with gh.
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'trunk'

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # Repository dispatch uses secrets.WEBHOOK_TOKEN; default GITHUB_TOKEN is unused.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # Repository dispatch uses secrets.WEBHOOK_TOKEN; default GITHUB_TOKEN is unused.
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 9 (`auto-translate.yml`, `brand-plugin-test.yml`, `codecoverage-main.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint-check-php.yml`, `lint-check-spa.yml`, `newfold-prep-release.yml`, `satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (not created — no changes applied in this run) |
| Permissions commit | none |
| Timeouts commit | none |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `auto-translate.yml` *(present-day file has `permissions: {}` but not the required two-line comment block immediately above it; comments still missing vs policy.)* |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-download.yml` *(workflow-level permissions are currently broad `contents`/`pull-requests` writes instead of empty defaults — needs restructuring.)* |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-upload.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-check-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-check-spa.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| brand-plugin-test.yml | 4 jobs were missing a scoped `permissions:` directive | setup | `permissions: {}` [3] |
| brand-plugin-test.yml | 4 jobs were missing a scoped `permissions:` directive | bluehost | `contents: read` [2] |
| brand-plugin-test.yml | 4 jobs were missing a scoped `permissions:` directive | hostgator | `contents: read` [2] |
| brand-plugin-test.yml | 4 jobs were missing a scoped `permissions:` directive | crazydomains | `contents: read` [2] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | codecoverage | `contents: write`, `pull-requests: write` [3] *(checkout + push to `gh-pages` via `stefanzweifel/git-auto-commit-action` with `GITHUB_TOKEN`; PR comments via `mshick/add-pr-comment`.)* |
| i18n-crowdin-download.yml | 1 job was missing job-level scoped permissions matching current workflow intent | call-crowdin-workflow | `contents: write`, `pull-requests: write` [2] *(align with reusable Crowdin download workflow that opens/updates PRs; exact minimum depends on upstream `newfold-labs/workflows` behavior.)* |
| i18n-crowdin-upload.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-upload-workflow | `contents: read` [2] *(typical minimum for callers of repo-touching reusable workflows on a private repo; confirm against called workflow.)* |
| lint-check-php.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| lint-check-spa.yml | 1 job was missing a scoped `permissions:` directive | lint-check-spa | `contents: read` [3] |
| newfold-prep-release.yml | 1 job already declares permissions but omitted per-permission trailing comments and places `permissions` before `uses` (policy calls for `permissions` immediately after `runs-on`/`uses`) | prep-release | add inline comments on `contents: write` and `pull-requests: write`; reorder to follow `uses:` per audit rule [3] |
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] *(dispatch uses `secrets.WEBHOOK_TOKEN`, not `github.token`; default token scopes need not be elevated.)* |
| auto-translate.yml | 1 job declares permissions but lacks required trailing comments on each permission and ordering vs `uses:` may need tightening to match audit placement rule | translate | annotate `contents: write`, `pull-requests: write`; verify placement after `uses:` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `i18n-crowdin-download.yml` :: *(workflow-level)*: BEFORE `contents: write` / `pull-requests: write` at workflow scope -> AFTER empty default `permissions: {}` at workflow scope + same scopes moved/reflected at job level with comments — workflow-wide elevated grants violate least-privilege baseline -- [3] |
| 2 | `newfold-prep-release.yml` :: `prep-release`: BEFORE permissions precede `uses:` -> AFTER permissions immediately following `uses:` (per audit ordering rule) — organizational compliance with instructed placement -- [2] |
| 3 | `auto-translate.yml` :: `translate`: BEFORE uncommented permission keys -> AFTER each permission includes trailing justification comment; optionally reorder relative to `uses:` — align with mandated documentation style -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| auto-translate.yml | translate | `30` | reusable translation automation; guard against hung Crowdin/API steps without altering any existing timeouts (none present). |
| brand-plugin-test.yml | setup | `30` | lightweight shell-only job; prevents stuck queued runners. |
| brand-plugin-test.yml | bluehost | `30` | Cypress/module-plugin integration via reusable workflow; typical CI ceiling unless upstream runtime proves insufficient. |
| brand-plugin-test.yml | hostgator | `30` | same rationale as `bluehost`. |
| brand-plugin-test.yml | crazydomains | `30` | same rationale as `bluehost`. |
| codecoverage-main.yml | codecoverage | `90` | matrix across many PHP versions plus Composer, Codeception, coverage merge, badge generation, optional PR comment assembly; higher ceiling than lint-only jobs. |
| i18n-crowdin-download.yml | call-crowdin-workflow | `30` | workflow_dispatch Crowdin sync; bounded external I/O. |
| i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `30` | workflow_dispatch Crowdin upload; bounded external I/O. |
| lint-check-php.yml | phpcs | `30` | Composer + PHPCS on diff-limited PHP sets. |
| lint-check-spa.yml | lint-check-spa | `30` | npm tooling + WP scripts lint passes. |
| newfold-prep-release.yml | prep-release | `30` | release preparation reusable workflow; manual dispatch safeguard. |
| satis-update.yml | webhook | `10` | short webhook/dispatch-only job with no heavy build. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Glob verified: exactly nine files match `.github/workflows/*.yml`; no `.yaml` workflows present under `.github/workflows`. |
| 2 | Several jobs delegate to `newfold-labs/workflows` reusable workflows; minimal caller permissions should be validated against those reusable definitions (especially Crowdin upload/download and brand-plugin-test). |
| 3 | Third-party actions (`peter-evans/repository-dispatch`, `technote-space/get-diff-action`, `stefanzweifel/git-auto-commit-action`, `mshick/add-pr-comment`, etc.) should be spot-checked against current docs if tightening beyond `contents`/`pull-requests` scopes. |
| 4 | This run produced analysis only on `trunk` with **no** local branch/commits per user constraint (**DO NOT push**). |


