### PR TITLE
Fix/featured images on blocks

### DIFF
--- a/assets/js/pending-featured-image.js
+++ b/assets/js/pending-featured-image.js
@@ -50,6 +50,59 @@
 	};
 
 	/**
+	 * Build inline border-radius value from block `style.border.radius` attributes.
+	 *
+	 * @param {object} attrs Block attributes.
+	 * @return {string|null} CSS border-radius value or null.
+	 */
+	function getBorderRadiusValue( attrs ) {
+		var border = attrs && attrs.style && attrs.style.border;
+		if ( ! border || ! border.radius ) {
+			return null;
+		}
+
+		var radius = border.radius;
+
+		if ( 'string' === typeof radius ) {
+			return radius;
+		}
+
+		if ( 'object' === typeof radius ) {
+			return ( radius.topLeft || '0' ) + ' '
+				+ ( radius.topRight || '0' ) + ' '
+				+ ( radius.bottomRight || '0' ) + ' '
+				+ ( radius.bottomLeft || '0' );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Merge layout and border styles so the editor preview matches frontend output.
+	 *
+	 * @param {object} attrs Block attributes.
+	 * @return {object} Style object for the pending `<img>`.
+	 */
+	function getPendingImageStyle( attrs ) {
+		attrs = attrs || {};
+
+		var style = {
+			width: '100%',
+			height: attrs.height || 'auto',
+			aspectRatio: attrs.aspectRatio || 'auto',
+			objectFit: attrs.scale || 'cover',
+			display: 'block',
+		};
+
+		var borderRadius = getBorderRadiusValue( attrs );
+		if ( borderRadius ) {
+			style.borderRadius = borderRadius;
+		}
+
+		return style;
+	}
+
+	/**
 	 * Resolve { url, hasFeatured } for the post this block instance refers to.
 	 *
 	 * - Inside a Query Loop the block receives a `context.postId` / `context.postType`
@@ -144,26 +197,21 @@
 				// Mirror the block's most common visual attributes so the preview
 				// matches what the frontend will render once the real image lands.
 				var attrs       = props.attributes || {};
-				var aspectRatio = attrs.aspectRatio || 'auto';
-				var height      = attrs.height || null;
+				var figureClass = [ baseClass, 'nfd-pending-featured-image', props.className ]
+					.filter( Boolean )
+					.join( ' ' );
 
 				return createElement(
 					'figure',
 					{
-						className: baseClass + ' nfd-pending-featured-image',
+						className: figureClass,
 						style: { margin: 0 },
 					},
 					createElement( 'img', {
 						src: data.url,
 						alt: '',
 						'data-nfd-pending-image': 'true',
-						style: {
-							width: '100%',
-							height: height || 'auto',
-							aspectRatio: aspectRatio,
-							objectFit: 'cover',
-							display: 'block',
-						},
+						style: getPendingImageStyle( attrs ),
 					} )
 				);
 			};

--- a/assets/js/pending-featured-image.js
+++ b/assets/js/pending-featured-image.js
@@ -1,0 +1,175 @@
+/**
+ * NFD Onboarding — Pending Featured Image preview in the block editor.
+ *
+ * The block editor renders `core/post-featured-image` (and `woocommerce/product-image`)
+ * client-side and only looks at the post's `featured_media` field; PHP filters such
+ * as `post_thumbnail_html` or `render_block_core/post-featured-image` never run for
+ * the editor canvas, so a post whose image is still "pending" (stored in the
+ * `nfd_image_url` meta) shows nothing in the editor even though it renders correctly
+ * on the frontend.
+ *
+ * This script wraps the target blocks' edit component with a small HOC: when the
+ * current post (or the contextual Query Loop / WooCommerce product) has
+ * `nfd_image_url` set and no real `featured_media`, we render an <img> with that
+ * URL on the fly. Nothing is saved to the post — it's purely a visual preview that
+ * mirrors the frontend output.
+ *
+ * Plain-JS on purpose: no build step, no React imports. Uses only the WP globals
+ * (wp.hooks, wp.data, wp.element, wp.compose) provided by the editor enqueue
+ * dependencies.
+ *
+ * @package NewfoldLabs\WP\Module\Onboarding
+ */
+
+( function ( wp ) {
+	'use strict';
+
+	if (
+		! wp ||
+		! wp.hooks ||
+		! wp.data ||
+		! wp.element ||
+		! wp.compose
+	) {
+		return;
+	}
+
+	var addFilter                  = wp.hooks.addFilter;
+	var createHigherOrderComponent = wp.compose.createHigherOrderComponent;
+	var createElement              = wp.element.createElement;
+	var useSelect                  = wp.data.useSelect;
+
+	var META_KEY  = 'nfd_image_url';
+	var FILTER_ID = 'nfd-onboarding/with-pending-featured-image';
+
+	// Blocks we wrap. Each maps to the outer figure className we emit so the
+	// preview matches the block's frontend wrapper (and inherits its styling).
+	var TARGET_BLOCKS = {
+		'core/post-featured-image': 'wp-block-post-featured-image',
+		'woocommerce/product-image': 'wc-block-components-product-image wp-block-woocommerce-product-image',
+	};
+
+	/**
+	 * Resolve { url, hasFeatured } for the post this block instance refers to.
+	 *
+	 * - Inside a Query Loop the block receives a `context.postId` / `context.postType`
+	 *   and we read that record from the `core` entity store.
+	 * - WooCommerce variants may expose the product id under `productId` or
+	 *   inside a `query`/`singleProduct` object — we probe those too.
+	 * - Otherwise we fall back to the currently edited post via `core/editor`.
+	 *
+	 * @param {object} props BlockEdit props (with optional `context`).
+	 * @return {{url: string, hasFeatured: boolean}} pending-image data
+	 */
+	function useNfdPendingImageData( props ) {
+		var ctx = props && props.context ? props.context : null;
+
+		// Try a handful of context shapes used by core Query Loop and various
+		// WooCommerce block variants.
+		var postId =
+			( ctx && ctx.postId ) ||
+			( ctx && ctx.productId ) ||
+			( ctx && ctx.singleProduct && ctx.singleProduct.id ) ||
+			( ctx && ctx.query && ctx.query.postId ) ||
+			0;
+
+		var postType =
+			( ctx && ctx.postType ) ||
+			( ctx && ctx.productId ? 'product' : '' ) ||
+			( ctx && ctx.singleProduct ? 'product' : '' ) ||
+			'';
+
+		// `woocommerce/product-image` is always about a product; if we have any
+		// id from context but missed the type, default to 'product'.
+		if ( postId && ! postType && props.name === 'woocommerce/product-image' ) {
+			postType = 'product';
+		}
+
+		return useSelect(
+			function ( select ) {
+				// Query Loop / template / WC context: resolve from the entity store.
+				if ( postId && postType ) {
+					var record = select( 'core' ).getEntityRecord(
+						'postType',
+						postType,
+						postId
+					);
+					if ( ! record ) {
+						return { url: '', hasFeatured: false };
+					}
+					var ctxMeta = record.meta || {};
+					return {
+						url: ctxMeta[ META_KEY ] || '',
+						hasFeatured: !! record.featured_media,
+					};
+				}
+
+				// Default: currently edited post.
+				var editor = select( 'core/editor' );
+				if ( ! editor ) {
+					return { url: '', hasFeatured: false };
+				}
+				var meta = editor.getEditedPostAttribute( 'meta' ) || {};
+				return {
+					url: meta[ META_KEY ] || '',
+					hasFeatured: !! editor.getEditedPostAttribute( 'featured_media' ),
+				};
+			},
+			[ postId, postType ]
+		);
+	}
+
+	/**
+	 * Higher-order component wrapping the target blocks. Returns the original
+	 * BlockEdit unless we have a pending image URL and no real featured attachment,
+	 * in which case we render an <img> with the meta URL.
+	 *
+	 * The block toolbar is rendered by Gutenberg's BlockListBlock wrapper (outside
+	 * of BlockEdit), so replacing the inner output does not remove block controls.
+	 */
+	var withNfdPendingImage = createHigherOrderComponent(
+		function ( BlockEdit ) {
+			return function ( props ) {
+				var baseClass = TARGET_BLOCKS[ props.name ];
+				if ( ! baseClass ) {
+					return createElement( BlockEdit, props );
+				}
+
+				var data = useNfdPendingImageData( props );
+
+				if ( ! data.url || data.hasFeatured ) {
+					return createElement( BlockEdit, props );
+				}
+
+				// Mirror the block's most common visual attributes so the preview
+				// matches what the frontend will render once the real image lands.
+				var attrs       = props.attributes || {};
+				var aspectRatio = attrs.aspectRatio || 'auto';
+				var height      = attrs.height || null;
+
+				return createElement(
+					'figure',
+					{
+						className: baseClass + ' nfd-pending-featured-image',
+						style: { margin: 0 },
+					},
+					createElement( 'img', {
+						src: data.url,
+						alt: '',
+						'data-nfd-pending-image': 'true',
+						style: {
+							width: '100%',
+							height: height || 'auto',
+							aspectRatio: aspectRatio,
+							objectFit: 'cover',
+							display: 'block',
+						},
+					} )
+				);
+			};
+		},
+		'withNfdPendingImage'
+	);
+
+	addFilter( 'editor.BlockEdit', FILTER_ID, withNfdPendingImage );
+} )( window.wp );

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -73,6 +73,9 @@ function nfd_wp_module_onboarding_register() {
 				if ( ! defined( 'NFD_ONBOARDING_BUILD_URL' ) && defined( 'NFD_ONBOARDING_VERSION' ) ) {
 					define( 'NFD_ONBOARDING_BUILD_URL', $container->plugin()->url . 'vendor/newfold-labs/wp-module-onboarding/build/' . NFD_ONBOARDING_VERSION );
 				}
+				if ( ! defined( 'NFD_ONBOARDING_PLUGIN_URL' ) ) {
+					define( 'NFD_ONBOARDING_PLUGIN_URL', $container->plugin()->url . 'vendor/newfold-labs/wp-module-onboarding' );
+				}
 				if ( ! defined( 'NFD_ONBOARDING_PLUGIN_DIRNAME' ) ) {
 					define( 'NFD_ONBOARDING_PLUGIN_DIRNAME', dirname( $container->plugin()->basename ) );
 				}
@@ -115,6 +118,8 @@ if ( is_callable( 'add_action' ) ) {
 			delete_transient( 'nfd_site_capabilities' );
 		}
 	);
+
+
 	// Queue content image sideloading for onboarding-generated pages when onboarding completes.
 	add_action( 'newfold/onboarding/completed', array( SiteGenImageService::class, 'schedule_after_onboarding' ) );
 	// Add action to process image sideload queue for onboarding-generated pages

--- a/includes/Services/ThumbnailService.php
+++ b/includes/Services/ThumbnailService.php
@@ -112,13 +112,8 @@ class ThumbnailService {
 		if ( ! ( $product instanceof \WC_Product ) || ! $this->product_has_nfd_image_meta( $product ) ) {
 			return '';
 		}
-		if ( $product->get_image_id() ) {
-			return '';
-		}
 
-		$url = esc_url_raw( trim( $this->get_nfd_image_meta_raw_for_product( $product ) ) );
-
-		return $url ? $url : '';
+		return $this->get_nfd_pending_image_url_for_post( (int) $product->get_id() );
 	}
 
 	/**
@@ -328,19 +323,28 @@ class ThumbnailService {
 			if ( preg_match( $pattern, $block_content, $m ) ) {
 				$img_tag = $m[0];
 				$style   = '';
+				$class   = 'wp-post-image';
+
 				if ( preg_match( '/\sstyle=("|\')(.*?)\1/i', $img_tag, $sm ) ) {
 					$style = $sm[2];
 				}
+				if ( preg_match( '/\sclass=("|\')(.*?)\1/i', $img_tag, $cm ) ) {
+					$class = str_replace( 'woocommerce-placeholder', 'wp-post-image', $cm[2] );
+					$class = trim( preg_replace( '/\s+/', ' ', $class ) );
+				}
 
-				$new_img = '<img src="' . esc_url( $url ) . '"'
-					. ( '' !== $style ? ' style="' . esc_attr( $style ) . '"' : '' )
-					. ' class="wp-post-image"'
-					. ' alt="' . esc_attr( $product->get_name() ) . '"'
-					. ' decoding="async"'
-					. ' loading="lazy"'
-					. ' />';
+				$new_img = $this->build_pending_image_html(
+					$post_id,
+					array(
+						'style' => $style,
+						'class' => $class,
+						'alt'   => $product->get_name(),
+					)
+				);
 
-				return str_replace( $img_tag, $new_img, $block_content );
+				if ( '' !== $new_img ) {
+					return str_replace( $img_tag, $new_img, $block_content );
+				}
 			}
 		}
 
@@ -378,40 +382,26 @@ class ThumbnailService {
 			return $block_content;
 		}
 
-		$post_id = (int) $block_instance->context['postId'];
-		if ( $post_id <= 0 || '' === get_post_meta( $post_id, PostTypeService::META_IMAGE_URL, true ) ) {
-			return $block_content;
-		}
-
-		$post_type = get_post_type( $post_id );
-		if ( 'product' !== $post_type ) {
-			return $block_content;
-		}
-
-		if ( has_post_thumbnail( $post_id ) ) {
-			return $block_content;
-		}
-
 		if ( null !== $block_content && '' !== $block_content ) {
 			return $block_content;
 		}
 
-		$product = function_exists( 'wc_get_product' ) ? wc_get_product( $post_id ) : null;
-		if ( ! ( $product instanceof \WC_Product ) ) {
+		$post_id = (int) $block_instance->context['postId'];
+		if ( $post_id <= 0 || '' === $this->get_nfd_pending_image_url_for_post( $post_id ) ) {
 			return $block_content;
 		}
 
-		$url = $this->get_nfd_pending_image_url_for_wc_product( $product );
-		if ( '' === $url ) {
+		if ( ! function_exists( 'render_block_core_post_featured_image' ) ) {
 			return $block_content;
 		}
 
-		$title = get_the_title( $post_id );
-		$img   = '<img src="' . esc_url( $url ) . '" alt="' . esc_attr( $title ) . '" class="wp-post-image" style="width:100%;height:100%;object-fit:cover;" loading="lazy" decoding="async" />';
-
-		$wrapper = get_block_wrapper_attributes( array( 'class' => 'wp-block-post-featured-image' ) );
-
-		return sprintf( '<figure %s>%s</figure>', $wrapper, $img );
+		// Re-run core rendering so block wrapper classes (e.g. nfd-rounded-t-lg) and img
+		// border styles from the pattern are preserved via `post_thumbnail_html`.
+		return render_block_core_post_featured_image(
+			$parsed_block['attrs'] ?? array(),
+			'',
+			$block_instance
+		);
 	}
 
 	/**
@@ -551,40 +541,109 @@ class ThumbnailService {
 
 
 	/**
+	 * Pending image URL from post meta when no featured attachment is set.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Non-empty esc_url_raw() value, or empty string.
+	 */
+	private function get_nfd_pending_image_url_for_post( int $post_id ): string {
+		if ( $post_id <= 0 || has_post_thumbnail( $post_id ) ) {
+			return '';
+		}
+
+		$raw = get_post_meta( $post_id, PostTypeService::META_IMAGE_URL, true );
+		if ( ! is_string( $raw ) || '' === trim( $raw ) ) {
+			return '';
+		}
+
+		$url = esc_url_raw( trim( $raw ) );
+
+		if ( ! $url || ! $this->is_usable_remote_image_url( $url ) ) {
+			return '';
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Build a pending featured `<img>` tag, merging caller attributes (e.g. border-radius from blocks).
+	 *
+	 * @param int          $post_id Post ID.
+	 * @param string|array $attr    Attributes passed to `get_the_post_thumbnail()` / `wp_get_attachment_image()`.
+	 * @return string
+	 */
+	private function build_pending_image_html( int $post_id, $attr = array() ): string {
+		$url = $this->get_nfd_pending_image_url_for_post( $post_id );
+		if ( '' === $url ) {
+			return '';
+		}
+
+		if ( ! is_array( $attr ) ) {
+			$attr = array();
+		}
+
+		$title = get_the_title( $post_id );
+
+		$attr = wp_parse_args(
+			$attr,
+			array(
+				'src'   => $url,
+				'class' => 'wp-post-image',
+				'alt'   => is_string( $title ) ? trim( strip_tags( $title ) ) : '',
+			)
+		);
+
+		$attr['src'] = $url;
+
+		if ( function_exists( 'wp_get_loading_optimization_attributes' ) ) {
+			$attr = array_merge( $attr, wp_get_loading_optimization_attributes( 'img', $attr, 'nfd_pending_image' ) );
+		}
+
+		if ( empty( $attr['decoding'] ) ) {
+			$attr['decoding'] = 'async';
+		}
+
+		$attr['data-nfd-pending-image'] = 'true';
+
+		$width  = isset( $attr['width'] ) && is_numeric( $attr['width'] ) ? absint( $attr['width'] ) : 0;
+		$height = isset( $attr['height'] ) && is_numeric( $attr['height'] ) ? absint( $attr['height'] ) : 0;
+		unset( $attr['width'], $attr['height'] );
+
+		$hwstring = ( $width && $height ) ? image_hwstring( $width, $height ) : '';
+		$attr     = array_map( 'esc_attr', $attr );
+
+		$html = rtrim( '<img ' . $hwstring );
+
+		foreach ( $attr as $name => $value ) {
+			if ( '' === $value && 'alt' !== $name ) {
+				continue;
+			}
+			$html .= ' ' . $name . '="' . $value . '"';
+		}
+
+		return $html . ' />';
+	}
+
+	/**
 	 * Use pending image URL for all post types.
 	 *
 	 * @param string       $html                    Thumbnail HTML.
 	 * @param int          $post_id                 Post ID.
 	 * @param int          $unused_post_thumbnail_id Attachment ID (unused; required by filter signature).
 	 * @param string|int[] $unused_size             Registered size name or [w, h] array (unused).
-	 * @param string|array $unused_attr             Extra img attributes (unused).
+	 * @param string|array $attr                    Extra img attributes from the caller (border-radius, etc.).
 	 * @return string
 	 */
-	public function use_pending_image_url( string $html, int $post_id, int $unused_post_thumbnail_id, $unused_size, $unused_attr ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public function use_pending_image_url( string $html, int $post_id, int $unused_post_thumbnail_id, $unused_size, $attr ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( '' !== $html && null !== $html ) {
 			return $html;
 		}
 
-		$post_id              = (int) $post_id;
-		$supported_post_types = array( PostTypeService::SERVICE_POST_TYPE, 'post' );
-		if ( $post_id <= 0 || ! in_array( get_post_type( $post_id ), $supported_post_types, true ) ) {
-			return $html;
-		}
-		if ( '' === get_post_meta( $post_id, PostTypeService::META_IMAGE_URL, true ) ) {
+		$post_id = (int) $post_id;
+		if ( $post_id <= 0 || '' === get_post_meta( $post_id, PostTypeService::META_IMAGE_URL, true ) ) {
 			return $html;
 		}
 
-		$url = esc_url_raw( trim( (string) get_post_meta( $post_id, PostTypeService::META_IMAGE_URL, true ) ) );
-		if ( '' === $url ) {
-			return $html;
-		}
-
-		return '<img src="' . esc_url( $url ) . '"'
-			. ' style="width:100%;height:100%;object-fit:cover;"'
-			. ' class="wp-post-image"'
-			. ' alt="' . esc_attr( get_the_title( $post_id ) ) . '"'
-			. ' decoding="async"'
-			. ' loading="lazy"'
-			. ' />';
+		return $this->build_pending_image_html( $post_id, $attr );
 	}
 }

--- a/includes/Services/ThumbnailService.php
+++ b/includes/Services/ThumbnailService.php
@@ -39,6 +39,36 @@ class ThumbnailService {
 		add_filter( 'render_block_core/post-featured-image', array( $this, 'use_pending_image_url_for_core_post_featured_block' ), 10, 3 );
 		add_filter( 'woocommerce_store_api_cart_item_images', array( $this, 'use_pending_image_url_for_cart_store_api' ), 10, 3 );
 		add_filter( 'rest_post_dispatch', array( $this, 'maybe_inject_images_wc_store_api_products' ), 10, 3 );
+
+		// Block editor preview: see enqueue_block_editor_assets() for context.
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
+	}
+
+	/**
+	 * Enqueue the JS that mirrors `nfd_image_url` into the block editor canvas.
+	 *
+	 * PHP filters cannot replace what the editor shows for `core/post-featured-image`
+	 * because the block renders client-side from the post's `featured_media` field.
+	 * The companion script wraps the block's edit component and renders the meta
+	 * URL as a preview when no real attachment is set, so the editor matches the
+	 * frontend output without altering any saved data.
+	 *
+	 * @return void
+	 */
+	public function enqueue_block_editor_assets(): void {
+		if ( ! defined( 'NFD_ONBOARDING_PLUGIN_URL' ) ) {
+			return;
+		}
+
+		$version = defined( 'NFD_ONBOARDING_VERSION' ) ? NFD_ONBOARDING_VERSION : false;
+
+		wp_enqueue_script(
+			'nfd-onboarding-pending-featured-image',
+			NFD_ONBOARDING_PLUGIN_URL . '/assets/js/pending-featured-image.js',
+			array( 'wp-hooks', 'wp-data', 'wp-element', 'wp-compose', 'wp-blocks', 'wp-editor' ),
+			$version,
+			true
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

### Fix pending featured images in the block editor
Display pending featured images in the block editor, matching frontend output.
The block editor renders `core/post-featured-image` and `woocommerce/product-image` client-side, so PHP filters like `post_thumbnail_html` or `render_block_core/post-featured-image` never run for the editor preview. 
Posts with images stored in the `nfd_image_url` meta (pending upload to the media library) show an empty placeholder in the editor, even though they render correctly on the frontend.
This change wraps the target blocks' edit components with a small HOC that detects when a post has `nfd_image_url` set and no real `featured_media` attachment, then renders the pending image URL directly so the editor preview matches the frontend output. Nothing is saved to the post—it's purely visual.

### Fix border radius
Pending featured images (stored in `nfd_image_url` before they are sideloaded into the media library) were not respecting border radius from block patterns. Images could show square corners on cards that should have rounded top corners.

This PR fixes that by preserving block styling when injecting pending images on the frontend and in the block editor.



## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->