### PR TITLE
fix custom fonts and global styles not applying on front end

### DIFF
--- a/includes/RestApi/GlobalStylesController.php
+++ b/includes/RestApi/GlobalStylesController.php
@@ -316,9 +316,7 @@ class GlobalStylesController {
 			array(
 				'settings' => array(
 					'typography' => array(
-						'fontFamilies' => array(
-							'custom' => $font_families,
-						),
+						'fontFamilies' => $font_families,
 					),
 				),
 			)

--- a/includes/Services/GlobalStylesService.php
+++ b/includes/Services/GlobalStylesService.php
@@ -144,6 +144,11 @@ class GlobalStylesService {
 		$post_id      = $post_id ?? $this->global_styles_id;
 		$post_content = $post_content ?? $this->global_styles;
 
+		if ( is_array( $post_content ) ) {
+			$post_content['version']                      = \WP_Theme_JSON::LATEST_SCHEMA;
+			$post_content['isGlobalStylesUserThemeJSON'] = true;
+		}
+
 		$result = wp_update_post(
 			array(
 				'ID'           => $post_id,


### PR DESCRIPTION
Custom fonts and global styles weren't being applied on the front end. This passes the font families through in the shape WordPress expects (instead of nesting them under `custom`), and tags the global styles post with the latest `theme.json` schema version so it actually gets applied on the front end.