### PR TITLE
fix: update zod to v4 to unblock lint workflow on PR #1196

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,8 @@
 				"eslint-import-resolver-typescript": "^4.4.4",
 				"node-fetch": "^3.3.2",
 				"tailwindcss": "^3.4.19",
-				"webpack-merge": "^6.0.1"
+				"webpack-merge": "^6.0.1",
+				"zod": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=22.11.0",
@@ -4894,9 +4895,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4918,9 +4916,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4942,9 +4937,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4966,9 +4958,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4990,9 +4979,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5014,9 +5000,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7805,9 +7788,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7822,9 +7802,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7839,9 +7816,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7856,9 +7830,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7873,9 +7844,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7890,9 +7858,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7907,9 +7872,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7924,9 +7886,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -13167,6 +13126,16 @@
 				"devtools-protocol": "*"
 			}
 		},
+		"node_modules/chromium-bidi/node_modules/zod": {
+			"version": "3.23.8",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
 		"node_modules/ci-info": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -15629,16 +15598,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-react-hooks/node_modules/zod": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
@@ -28901,7 +28860,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.23.8",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"eslint-import-resolver-typescript": "^4.4.4",
 		"node-fetch": "^3.3.2",
 		"tailwindcss": "^3.4.19",
-		"webpack-merge": "^6.0.1"
+		"webpack-merge": "^6.0.1",
+		"zod": "^4.0.0"
 	},
 	"scripts": {
 		"build": "wp-scripts build ./src/onboarding.js ./src/DesignStudio/onboarding-design-studio.js ./src/DesignStudio/onboarding-design-studio.css",


### PR DESCRIPTION
## Summary

The **Run Lint Checks** CI job on PR #1196 was failing before any linting even ran, with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './v4/core' is not
defined by "exports" in node_modules/zod/package.json
```

**Root cause:** `eslint-plugin-react-hooks@7.1.1` (pulled in transitively by `@wordpress/eslint-plugin@25.8.0` via `@wordpress/scripts@32.6.0`) internally imports `zod/v4/core`, which only exists in zod v4. The `package-lock.json` on this branch had already resolved a nested `node_modules/eslint-plugin-react-hooks/node_modules/zod@4.4.3`, but Node.js was still finding the top-level `node_modules/zod@3.23.8` (v3) first when resolving the subpath import, causing the crash.

**Fix:** Pin `zod@^4.0.0` as an explicit `devDependency`. This causes npm to hoist zod v4 to the top-level `node_modules/zod` slot. `chromium-bidi`, which specifically needs zod v3, keeps its own nested copy at `node_modules/chromium-bidi/node_modules/zod@3.23.8`.

## Changes

- `package.json` — adds `"zod": "^4.0.0"` to `devDependencies`
- `package-lock.json` — top-level zod bumped from `3.23.8` → `4.4.3`; chromium-bidi's nested zod@3.23.8 entry added; eslint-plugin-react-hooks' nested zod@4.4.3 entry removed (now uses hoisted top-level)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToC64oWXr52L6MMAzm7Xik)_