### PR TITLE
Updated workflows to main-networksolutions for NS brands

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -3,7 +3,7 @@ name: Check for Updates to Translations
 on:
   push:
     branches:
-      - 'main'
+      - 'main-networksolutions'
   workflow_dispatch:
 
 # Cancels all previous workflow runs for the branch that have not completed.

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -29,8 +29,8 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
 
-  bluehost:
-    name: Bluehost Build and Test Playwright
+  netsol:
+    name: Netsol Build and Test Playwright
     needs: setup
     permissions:
       contents: read
@@ -38,11 +38,11 @@ jobs:
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
-      plugin-repo: 'newfold-labs/wp-plugin-bluehost'
+      plugin-repo: 'newfold-labs/wp-plugin-web'
     secrets: inherit
 
-  bluehost-dev:
-    name: Bluehost Dev Build and Test Playwright
+  netsol-dev:
+    name: Netsol Dev Build and Test Playwright
     needs: setup
     permissions:
       contents: read
@@ -50,7 +50,7 @@ jobs:
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
-      plugin-repo: 'newfold-labs/wp-plugin-bluehost'
+      plugin-repo: 'newfold-labs/wp-plugin-web'
       plugin-branch: 'develop'
-      artifact-name: 'wp-plugin-bluehost-develop'
+      artifact-name: 'wp-plugin-web-develop'
     secrets: inherit

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [ opened, reopened, ready_for_review, synchronize ]
     branches:
-      - main
+      - main-networksolutions
       - trunk
   workflow_dispatch:
 

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -1,16 +1,29 @@
 name: Codecoverage-Main
 
+# DISABLED for main-networksolutions (3.x NS line).
+# Code coverage continues to run on the `main` branch (4.x).
+#
+# Technical reasons automatic coverage is not enabled here:
+# 1. reusable-codecoverage.yml (newfold-labs/workflows) hardcodes `github.ref == 'refs/heads/main'`
+#    for gh-pages commits, README badge updates, and the PR baseline coverage percentage — so pushes
+#    to main-networksolutions would run tests but would not publish or compare coverage correctly.
+# 2. gh-pages is shared across the whole repo (e.g. gh-pages/phpunit/); enabling coverage on both
+#    main and main-networksolutions would produce conflicting reports and badge values.
+#
+# To re-enable for NS: coordinate an upstream fix in newfold-labs/workflows (e.g. a production-branch
+# input or separate gh-pages path), then uncomment the push/pull_request triggers below.
+
 # Runs PHPUnit unit and Codeception wp-browser wpunit tests, merges the code coverage, commits the html report to
 # GitHub Pages, generates a README badge with the coverage percentage.
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [ opened, reopened, ready_for_review, synchronize ]
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main-networksolutions
+  # pull_request:
+  #   types: [ opened, reopened, ready_for_review, synchronize ]
+  #   branches:
+  #     - main-networksolutions
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -6,7 +6,7 @@ on:
       base_branch:
         description: 'Base branch for the pull request'
         required: false
-        default: 'main'
+        default: 'main-networksolutions'
 
 permissions:
   contents: write

--- a/.github/workflows/lint-check-php.yml
+++ b/.github/workflows/lint-check-php.yml
@@ -1,10 +1,14 @@
 name: 'Lint Checker: PHP'
 on:
   push:
+    branches:
+      - main-networksolutions
     paths:
       - '**.php'
       - '!build/**/*.php'
   pull_request:
+    branches:
+      - main-networksolutions
     types: [opened, edited, reopened, ready_for_review]
     paths:
       - '**.php'

--- a/.github/workflows/lint-check-spa.yml
+++ b/.github/workflows/lint-check-spa.yml
@@ -2,10 +2,14 @@ name: "Lint Checker: Onboarding SPA"
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main-networksolutions
     paths:
       - "src/**/*.js"
       - "src/**/*.scss"
   pull_request:
+    branches:
+      - main-networksolutions
     types: [opened, edited, reopened, ready_for_review]
     paths:
       - "src/**/*.js"

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -27,7 +27,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     with:
       module-repo: ${{ github.repository }}
-      module-branch: 'main'
+      module-branch: 'main-networksolutions'
       level: ${{ inputs.level }}
       json-file: 'package.json'
       php-file: 'bootstrap.php'


### PR DESCRIPTION


## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Updated the branch from main to main-networksolutions so the workflows run on main-networksolutions branch for the networksolutions brands. 
**Workflow files Updated:**
- **auto-translate.yml** — Run translation checks on push to `main-networksolutions` instead of `main`.
- **brand-plugin-test-playwright.yml** — Run Playwright tests for PRs targeting `main-networksolutions` (keeps `trunk`).
- **lint-check-php.yml** — Scope PHP lint to push/PR on `main-networksolutions` only.
- **lint-check-spa.yml** — Scope SPA lint to push/PR on `main-networksolutions` only.
- **newfold-prep-release.yml** — Point release prep at `main-networksolutions` so release PRs merge into the NS branch.
- **i18n-crowdin-download.yml** — Default Crowdin download PR base branch to `main-networksolutions`.
- **codecoverage-main.yml** — Disable automatic coverage on NS (commented `push`/`pull_request` triggers); document why (shared reusable workflow hardcodes `main`, shared `gh-pages`). Coverage remains on `main` only.

## Not changed

- **`main` branch workflows** — Unchanged; 4.x line unaffected.
- **dependabot.yml** — Still targets `main` only; NS dependency updates remain manual.
- **satis-update.yml** — Still triggers on GitHub Release creation (branch-agnostic).

## Test plan

- [ ] Merge PR into `main-networksolutions` and confirm **auto-translate** runs on push.
- [ ] Open a test PR into `main-networksolutions` with PHP/JS changes and confirm **lint** + **Playwright** run.
- [ ] Confirm **codecoverage** does not run automatically on `main-networksolutions`.
- [ ] Manually run **Newfold Prepare Release** from `main-networksolutions` and verify release PR targets NS branch.

---

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [x] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->