### PR TITLE
fixed issue of privacy page in nav

### DIFF
--- a/includes/RestApi/SiteContentController.php
+++ b/includes/RestApi/SiteContentController.php
@@ -102,6 +102,10 @@ class SiteContentController {
 	/**
 	 * Setup the navigation menu from publish pages, including WooCommerce Shop for ecommerce sites.
 	 *
+	 * Each page entry carries id, title, slug, link, is_front_page, is_contact_page and
+	 * an optional page_purpose. Pages with a purpose are policy/support pages and are
+	 * kept out of the primary nav — see SiteNavigationService::is_policy_nav_page().
+	 *
 	 * @param \WP_REST_Request $request The REST request object.
 	 * @return \WP_REST_Response|\WP_Error
 	 */

--- a/includes/Services/SiteNavigationService.php
+++ b/includes/Services/SiteNavigationService.php
@@ -23,7 +23,7 @@ class SiteNavigationService {
 	 * Setup the site navigation menu from client-created pages.
 	 *
 	 * @param string $site_type Site type from discovery (e.g. ecommerce, business).
-	 * @param array  $pages     Pages from publish ctx.createdPages: id, title, link, slug.
+	 * @param array  $pages     Pages from publish ctx.createdPages: id, title, link, slug, page_purpose.
 	 * @return bool True if the navigation menu was setup, false otherwise.
 	 */
 	public function setup_site_nav_menu( string $site_type, array $pages ): bool {
@@ -97,6 +97,10 @@ class SiteNavigationService {
 		$nav_items = array();
 
 		foreach ( $pages as $page ) {
+			if ( self::is_policy_nav_page( $page ) ) {
+				continue;
+			}
+
 			$id    = (int) ( $page['id'] ?? 0 );
 			$title = $page['title'] ?? '';
 			$link  = $page['link'] ?? '';
@@ -257,6 +261,34 @@ class SiteNavigationService {
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Whether a page is a policy/support page that belongs in the footer only.
+	 *
+	 * Legal and store-policy pages are linked from the footer, so listing them in
+	 * the primary nav duplicates the destination and crowds out the pages that
+	 * carry the site's information architecture.
+	 *
+	 * Decided solely on `page_purpose`, which the platform sends for every page it
+	 * generates (null when the page isn't a policy page). Matching on slug instead
+	 * would be fragile — the sitemap agent can name a policy page freely (e.g.
+	 * "shipping-info"), and slugs vary by site locale — so no slug fallback here.
+	 *
+	 * Contact pages are always kept: they are a primary destination, and the
+	 * platform never tags them with a purpose.
+	 *
+	 * @param array $page Publish page payload.
+	 * @return bool
+	 */
+	public static function is_policy_nav_page( array $page ): bool {
+		if ( ! empty( $page['is_contact_page'] ) ) {
+			return false;
+		}
+
+		$purpose = $page['page_purpose'] ?? null;
+
+		return is_string( $purpose ) && '' !== trim( $purpose );
 	}
 
 	/**

--- a/src/app/hooks/publish/steps.js
+++ b/src/app/hooks/publish/steps.js
@@ -115,6 +115,9 @@ export async function runPages( { generationData, ctx } ) {
 				link: page.link,
 				is_front_page: !! entry.is_front_page,
 				is_contact_page: !! entry.is_contact_page,
+				// Policy/support pages are tagged by the platform; the nav step
+				// uses this to keep them out of the primary navigation.
+				page_purpose: entry.page_purpose ?? null,
 			} );
 			if ( isHome ) {
 				homepageId = page.id;

--- a/tests/wpunit/SiteNavigationServiceWPUnitTest.php
+++ b/tests/wpunit/SiteNavigationServiceWPUnitTest.php
@@ -214,4 +214,114 @@ class SiteNavigationServiceWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTes
 		$this->assertSame( 6, substr_count( $nav[0]->post_content, 'wp:navigation-link' ) );
 		$this->assertStringNotContainsString( '"kind":"taxonomy"', $nav[0]->post_content );
 	}
+
+	/**
+	 * A page_purpose tag marks a policy page, whatever its slug.
+	 *
+	 * @return void
+	 */
+	public function test_is_policy_nav_page_uses_page_purpose_over_slug() {
+		$this->assertTrue(
+			SiteNavigationService::is_policy_nav_page(
+				array(
+					'slug'         => 'shipping-info',
+					'page_purpose' => 'shipping',
+				)
+			)
+		);
+
+		$this->assertTrue(
+			SiteNavigationService::is_policy_nav_page(
+				array(
+					'slug'         => 'datenschutz-agb',
+					'page_purpose' => 'legal',
+				)
+			)
+		);
+	}
+
+	/**
+	 * Without page_purpose, a policy-looking slug is not enough — no slug guessing.
+	 *
+	 * @return void
+	 */
+	public function test_is_policy_nav_page_requires_page_purpose_not_slug_guessing() {
+		$this->assertFalse( SiteNavigationService::is_policy_nav_page( array( 'slug' => 'privacy-terms' ) ) );
+		$this->assertFalse( SiteNavigationService::is_policy_nav_page( array( 'slug' => 'returns-refunds' ) ) );
+		$this->assertFalse(
+			SiteNavigationService::is_policy_nav_page(
+				array(
+					'slug'         => 'privacy-terms',
+					'page_purpose' => '',
+				)
+			)
+		);
+	}
+
+	/**
+	 * Regular pages stay in the nav, and a contact page is never treated as policy.
+	 *
+	 * @return void
+	 */
+	public function test_is_policy_nav_page_keeps_regular_and_contact_pages() {
+		$this->assertFalse( SiteNavigationService::is_policy_nav_page( array( 'slug' => 'about' ) ) );
+		$this->assertFalse( SiteNavigationService::is_policy_nav_page( array( 'slug' => 'our-story' ) ) );
+		$this->assertFalse(
+			SiteNavigationService::is_policy_nav_page(
+				array(
+					'slug'            => 'contact',
+					'is_contact_page' => true,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Policy pages never reach the generated primary nav, while the contact page does.
+	 *
+	 * @return void
+	 */
+	public function test_setup_site_nav_menu_excludes_policy_pages() {
+		$definitions = array(
+			array( 'Home', 'home', null, false ),
+			array( 'About', 'about', null, false ),
+			array( 'Contact', 'contact', null, true ),
+			array( 'Shipping Information', 'shipping-info', 'shipping', false ),
+			array( 'Privacy & Terms', 'privacy-terms', 'legal', false ),
+			array( 'Help Centre', 'help-centre', 'faq', false ),
+		);
+
+		$pages = array();
+		foreach ( $definitions as list( $title, $slug, $purpose, $is_contact ) ) {
+			$pages[] = array(
+				'id'              => (int) self::factory()->post->create( array( 'post_type' => 'page' ) ),
+				'title'           => $title,
+				'link'            => 'http://example.org/' . $slug . '/',
+				'slug'            => $slug,
+				'is_front_page'   => 'home' === $slug,
+				'is_contact_page' => $is_contact,
+				'page_purpose'    => $purpose,
+			);
+		}
+
+		( new SiteNavigationService() )->setup_site_nav_menu( 'business', $pages );
+
+		$nav = get_posts(
+			array(
+				'post_type'   => 'wp_navigation',
+				'numberposts' => 1,
+			)
+		);
+
+		$this->assertNotEmpty( $nav );
+		$content = $nav[0]->post_content;
+
+		$this->assertSame( 3, substr_count( $content, 'wp:navigation-link' ) );
+		$this->assertStringContainsString( '"label":"Home"', $content );
+		$this->assertStringContainsString( '"label":"About"', $content );
+		$this->assertStringContainsString( '"label":"Contact"', $content );
+		$this->assertStringNotContainsString( 'Shipping Information', $content );
+		$this->assertStringNotContainsString( 'Privacy', $content );
+		$this->assertStringNotContainsString( 'Help Centre', $content );
+	}
 }


### PR DESCRIPTION
## Proposed changes

https://newfold.atlassian.net/browse/PRESS0-4971

## Summary

The ai-platform now tags every policy/support page (Shipping, Returns & Refunds,
FAQ, Privacy & Terms) it generates with a `page_purpose` field, so this module can
finally stop guessing. Today `setup_site_nav_menu()` lists every published page in
the primary nav, including these — legal/store-policy pages belong in the footer
only, not duplicated in the header.

## Changes

- `SiteNavigationService::is_policy_nav_page()` (new) — decides purely on
  `page_purpose`: a non-empty value means the page is policy/support and is
  excluded from the primary nav. Contact pages are always kept regardless of
  purpose. 
- `get_site_navigation_items()` now skips pages where `is_policy_nav_page()` is
  true, before building nav items.
- `src/app/hooks/publish/steps.js` — `runPages()` now carries `page_purpose`
  through into `ctx.createdPages`, so it reaches the `setup-nav-menu` REST call.
- `tests/wpunit/SiteNavigationServiceWPUnitTest.php` — new coverage:
  `page_purpose` takes precedence regardless of slug, pages without a purpose
  stay in nav (no slug-based guessing), contact pages are never treated as
  policy, and an end-to-end `setup_site_nav_menu()` case with a mixed page set
  asserts the nav only contains Home/About/Contact.


## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->