### PR TITLE
Fix onboarding logo upload spinner under client-side media processing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+const path = require( 'path' );
+const defaultConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
+
+/**
+ * Jest config for the onboarding SPA (JS unit/integration tests).
+ *
+ * Extends @wordpress/scripts' default unit preset and teaches it the same
+ * "@/" -> src/app alias the webpack build uses.
+ */
+module.exports = {
+	...defaultConfig,
+	rootDir: path.resolve( __dirname ),
+	moduleNameMapper: {
+		...( defaultConfig.moduleNameMapper || {} ),
+		'^@/(.*)$': '<rootDir>/src/app/$1',
+	},
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
 		"@wordpress/scripts": "^31.6.0",
 		"eslint-import-resolver-alias": "^1.1.2",
 		"node-fetch": "^3.3.2",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
 		"tailwindcss": "^3.4.19",
 		"webpack-merge": "^6.0.1"
 	},
@@ -31,7 +33,8 @@
 		"post-set-version": "rm -rf ./build",
 		"lint:js": "wp-scripts lint-js ./src",
 		"lint:js:fix": "wp-scripts lint-js ./src --fix",
-		"test:unit": "npx wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins//phpunit.xml --verbose'"
+		"test:unit": "npx wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins//phpunit.xml --verbose'",
+		"test:unit:js": "wp-scripts test-unit-js --config jest.config.js"
 	},
 	"dependencies": {
 		"@heroicons/react": "^2.2.0",

--- a/src/app/steps/Logo/LogoUploadInput.js
+++ b/src/app/steps/Logo/LogoUploadInput.js
@@ -67,36 +67,33 @@ const LogoUploadInput = ( { isUploading, setIsUploading } ) => {
 		// Process the upload
 		setIsUploading( true );
 		/**
-		 * The uploadMedia function first calls the onFileChange immediately with a blob src.
-		 * Then it calls onFileChange again with the final uploaded object.
-		 * Since we're only interested in the final uploaded object...
-		 * The isOptimisticUrl flag is used to track the first call and ignore the blob src.
+		 * uploadMedia() reports progress through onFileChange, which may fire
+		 * more than once for a single upload. With server-side processing it
+		 * fires first with an optimistic placeholder (a blob URL and no id),
+		 * then again with the finalized attachment (which carries an id).
+		 * Since WordPress 7.1 enabled client-side media processing by default
+		 * (in supporting browsers), the placeholder callback is skipped and
+		 * only the finalized attachment is emitted — see wp.mediaUtils
+		 * .uploadMedia, gated on window.__clientSideMediaProcessing.
+		 *
+		 * Detect completion by the presence of an id rather than by call
+		 * order, so a lone finalized callback is not mistaken for the
+		 * placeholder and left spinning forever. Failures come through onError.
 		 */
-		let isOptimisticUrl = true;
 		uploadMedia( {
 			multiple: false,
 			filesList: [ file ],
 			onFileChange: ( files ) => {
-				if ( isOptimisticUrl ) {
-					isOptimisticUrl = false;
+				const media = files?.[ 0 ];
+				// Ignore the optimistic placeholder (blob URL, no id yet).
+				if ( ! media?.id ) {
 					return;
 				}
-				// If the file id is not found, set the error state and return
-				if ( ! files[ 0 ]?.id ) {
-					setError( {
-						status: true,
-						message: __( 'Failed to upload logo. Please try again.', 'wp-module-onboarding' ),
-					} );
-					setIsUploading( false );
-					return;
-				}
-				// Success...
-				// Set the logo in the input slice
+				// Finalized attachment — store the logo and stop the spinner.
 				dispatch( nfdOnboardingStore ).setLogo( {
-					id: files[ 0 ].id,
-					url: files[ 0 ].url,
+					id: media.id,
+					url: media.url,
 				} );
-				// Reset the uploading state
 				setIsUploading( false );
 			},
 			onError: ( e ) => {

--- a/src/app/steps/Logo/test/LogoUploadInput.test.js
+++ b/src/app/steps/Logo/test/LogoUploadInput.test.js
@@ -1,0 +1,159 @@
+/* eslint-env jest */
+/**
+ * Regression tests for the onboarding logo upload spinner.
+ *
+ * Bug (reported Aug 2026): uploading a logo in the onboarding flow spun
+ * forever and left the "Next" button disabled. Root cause: uploadMedia()
+ * only emits an optimistic placeholder onFileChange callback when server-side
+ * media processing is used. WordPress 7.1 turned on client-side media
+ * processing by default (in supporting browsers), so uploadMedia() emits a
+ * single finalized callback — which the old "skip the first callback" logic
+ * discarded, so isUploading never cleared.
+ *
+ * These tests drive LogoUploadInput with uploadMedia mocked to reproduce both
+ * callback shapes and assert the logo is stored and the spinner is cleared.
+ */
+import { act } from 'react';
+import { createElement, createRoot } from '@wordpress/element';
+import { uploadMedia } from '@wordpress/media-utils';
+
+import LogoUploadInput from '../LogoUploadInput';
+
+// `__` is provided as a global by the webpack build (ProvidePlugin); jest has
+// no such transform, so shim it to an identity function.
+global.__ = ( text ) => text;
+
+// Opt in to React 18's act() environment so state updates flush synchronously.
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockSetLogo = jest.fn();
+
+jest.mock( '@wordpress/media-utils', () => ( {
+	uploadMedia: jest.fn(),
+	validateMimeType: jest.fn(),
+	validateFileSize: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: () => ( { logo: null, selectedLocale: 'en_US' } ),
+	dispatch: () => ( { setLogo: mockSetLogo } ),
+} ) );
+
+jest.mock( '@/data/store', () => ( { nfdOnboardingStore: 'nfd/onboarding' } ) );
+
+jest.mock( '@/utils/analytics/hiive', () => ( {
+	OnboardingEvent: class {},
+	trackOnboardingEvent: jest.fn(),
+} ) );
+
+jest.mock( '@/utils/analytics/hiive/constants', () => ( {
+	ACTION_LOGO_UPLOAD_FAILED: 'logo_upload_failed',
+} ) );
+
+jest.mock( '../AiLogoCreator', () => ( { AiLogoCreator: () => null } ) );
+
+jest.mock( '@newfold/ui-component-library', () => ( {
+	Label: () => null,
+	Spinner: () => null,
+} ) );
+
+jest.mock( '@heroicons/react/24/outline', () => ( {
+	CloudArrowUpIcon: () => null,
+} ) );
+
+const FINAL_LOGO = { id: 42, url: 'https://example.test/logo.png' };
+
+let container;
+let root;
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+} );
+
+afterEach( () => {
+	act( () => root.unmount() );
+	container.remove();
+} );
+
+const renderInput = ( setIsUploading ) => {
+	act( () => {
+		root = createRoot( container );
+		root.render(
+			createElement( LogoUploadInput, { isUploading: false, setIsUploading } )
+		);
+	} );
+};
+
+const selectLogoFile = () => {
+	const input = container.querySelector( '#nfd-onboarding-logo-input' );
+	const file = new File( [ 'logo-bytes' ], 'logo.png', { type: 'image/png' } );
+	Object.defineProperty( input, 'files', { value: [ file ], configurable: true } );
+	act( () => {
+		input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+	} );
+};
+
+describe( 'LogoUploadInput', () => {
+	it( 'stores the logo and stops the spinner when client-side media processing emits a single finalized callback', () => {
+		// WordPress 7.1 client-side processing: no optimistic placeholder,
+		// only the finalized attachment.
+		uploadMedia.mockImplementation( ( { onFileChange } ) => {
+			onFileChange( [ FINAL_LOGO ] );
+		} );
+		const setIsUploading = jest.fn();
+
+		renderInput( setIsUploading );
+		selectLogoFile();
+
+		expect( mockSetLogo ).toHaveBeenCalledWith( { id: 42, url: FINAL_LOGO.url } );
+		expect( setIsUploading ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'still stores the logo when server-side processing emits the placeholder then the finalized callback', () => {
+		// Legacy behavior: optimistic blob placeholder first, finalized second.
+		uploadMedia.mockImplementation( ( { onFileChange } ) => {
+			onFileChange( [ { url: 'blob:placeholder' } ] );
+			onFileChange( [ FINAL_LOGO ] );
+		} );
+		const setIsUploading = jest.fn();
+
+		renderInput( setIsUploading );
+		selectLogoFile();
+
+		expect( mockSetLogo ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetLogo ).toHaveBeenCalledWith( { id: 42, url: FINAL_LOGO.url } );
+		expect( setIsUploading ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'ignores the optimistic placeholder callback (no id)', () => {
+		uploadMedia.mockImplementation( ( { onFileChange } ) => {
+			onFileChange( [ { url: 'blob:placeholder' } ] );
+		} );
+		const setIsUploading = jest.fn();
+
+		renderInput( setIsUploading );
+		selectLogoFile();
+
+		expect( mockSetLogo ).not.toHaveBeenCalled();
+		// Still uploading — the finalized callback has not arrived yet.
+		expect( setIsUploading ).not.toHaveBeenCalledWith( false );
+	} );
+
+	it( 'clears the spinner without storing a logo when the upload errors', () => {
+		uploadMedia.mockImplementation( ( { onError } ) => {
+			onError( new Error( 'upload failed' ) );
+		} );
+		const setIsUploading = jest.fn();
+
+		renderInput( setIsUploading );
+		selectLogoFile();
+
+		expect( mockSetLogo ).not.toHaveBeenCalled();
+		expect( setIsUploading ).toHaveBeenCalledWith( false );
+		// The component logs the upload error; assert it so jest-console
+		// treats the console.error as expected.
+		expect( console ).toHaveErrored();
+	} );
+} );


### PR DESCRIPTION
https://newfold.atlassian.net/browse/PRESS0-5059

## Proposed changes

In the onboarding flow, uploading a site logo spins forever — the logo is never applied and the **Next** button stays disabled, so the customer is stuck. Reported 2026-08-27 by support (customer account 154137568).

**Root cause.** `LogoUploadInput` uploads via `uploadMedia` from `@wordpress/media-utils` and assumes its `onFileChange` callback always fires **twice** — first an optimistic placeholder (a blob URL, no `id`), then the finalized attachment (with an `id`) — so it unconditionally skips the first callback via an `isOptimisticUrl` flag.

WordPress 7.1 graduated **client-side media processing** to on-by-default. In that mode, core's `wp.mediaUtils.uploadMedia` skips the optimistic placeholder callback (the code path is gated on `window.__clientSideMediaProcessing`) and emits **only** the finalized attachment. The module discards that single callback as the "optimistic" one, so `isUploading` is never cleared.

**Why now.** This upload code has not changed since May 2025. `@wordpress/media-utils` is externalized to core's `wp.mediaUtils` at build time, so its runtime behavior tracks the WordPress version on the server — WordPress 7.1 (Aug 2026) flipped the default. Client-side processing is only active in supporting browsers (Chromium, >2GB RAM, no `Save-Data`); Firefox/Safari/low-RAM devices fall back to server-side processing and still work, which is why the failure looks intermittent.

**Fix.** Detect upload completion by the presence of an `id` on the returned attachment rather than by call order. This is robust to both the one-callback (client-side processing) and two-callback (server-side processing) behaviors. Upload failures continue to be handled by `onError`.

**Tests.** Adds the module's first JS unit tests (`wp-scripts test-unit-js`, run with `npm run test:unit:js`). They render `LogoUploadInput` with `uploadMedia` mocked and assert the logo is stored and the spinner cleared for:
- a single finalized callback (client-side media processing) — **this is the regression**;
- the legacy placeholder-then-finalized sequence;
- the optimistic-only placeholder (still uploading); and
- the error path.

Verified as a mutation check: reverting only the source fix makes the single-finalized-callback test fail, and restoring it passes. `react`/`react-dom` are declared as devDependencies so the test harness can render.

> Note on CI coverage: the SPA lint workflow lints JS but does not run `test-unit-js`, so these tests are a local + regression guard rather than a gate here. The fix and tests were run and mutation-checked locally.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tests (adds or updates tests)

## Visual

Before: selecting a logo shows a spinner that never resolves; **Next** stays disabled.
After: the logo is applied and the step advances normally.

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the style guidelines of this project (`wp-scripts lint-js` passes on the changed files)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Further comments

Targets the `v3` branch (3.3.x), which is what ships in the Bluehost brand plugin (`^3.3.7`). The same pattern does not appear elsewhere in the module.
